### PR TITLE
Mobile: show filters in modal and remove menu button

### DIFF
--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -88,7 +88,6 @@ export function ExplorerShell({
           </button>
           <button className="dn-local-status" onClick={() => setModal("privacy")}><Icon name="shield" /> All analysis is local <i /></button>
           <button className="dn-icon-button dn-hide-mobile" aria-label="Help" onClick={() => setModal("help")}><Icon name="help" /></button>
-          <button className="dn-icon-button dn-show-mobile" aria-label="Menu"><Icon name="menu" /></button>
         </header>
 
         <nav className="dn-tabbar" aria-label="Explorer sections">
@@ -278,6 +277,7 @@ export function CategoryExplorerContent({
   onLoadMore: () => void;
 }) {
   const [areFiltersCollapsed, setAreFiltersCollapsed] = useState(false);
+  const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false);
 
   return (
     <main className={`dn-category-screen ${areFiltersCollapsed ? "is-filter-collapsed" : ""}`}>
@@ -309,29 +309,7 @@ export function CategoryExplorerContent({
                 </button>
               </div>
             </div>
-            <label className="dn-field dn-field--search">
-              <span>Search</span>
-              <div><Icon name="search" /><input value={filters.q} onChange={(event) => onFilterChange("q", event.target.value)} placeholder="Search findings..." /></div>
-            </label>
-            <FilterSelect label="Sort" value={filters.sort} onChange={(value) => onFilterChange("sort", value)} options={[["severity", "Severity / priority"], ["evidence", "Evidence strength"], ["publications", "Publication count"], ["alphabetical", "Alphabetical"]]} />
-            <FilterSelect label="Source" value={filters.source} onChange={(value) => onFilterChange("source", value)} options={optionList(profile.report.facets.sources, "All sources")} />
-            <MultiFilterSelect label="Evidence level" values={filters.evidence} onChange={(value) => onFilterChange("evidence", value)} options={profile.report.facets.evidenceTiers.map((value) => [value, value])} />
-            <MultiFilterSelect
-              label="Clinical significance"
-              values={filters.significance}
-              onChange={(value) => onFilterChange("significance", value)}
-              options={profile.report.facets.clinicalSignificances.map((value) => [value, profile.report.facets.clinicalSignificanceLabels[value] ?? value])}
-            />
-            <MultiFilterSelect label="Repute" values={filters.repute} onChange={(value) => onFilterChange("repute", value)} options={profile.report.facets.reputes.map((value) => [value, value])} />
-            <MultiFilterSelect label="Coverage" values={filters.coverage} onChange={(value) => onFilterChange("coverage", value)} options={profile.report.facets.coverages.map((value) => [value, value])} />
-            <MultiFilterSelect label="Publication bucket" values={filters.publications} onChange={(value) => onFilterChange("publications", value)} options={profile.report.facets.publicationBuckets.map((value) => [value, value])} />
-            <MultiFilterSelect label="Gene" values={filters.gene} onChange={(value) => onFilterChange("gene", value)} options={profile.report.facets.genes.map((value) => [value, value])} />
-            <MultiFilterSelect
-              label="Topic / condition"
-              values={filters.tag}
-              onChange={(value) => onFilterChange("tag", value)}
-              options={[...profile.report.facets.tags, ...profile.report.facets.conditions].filter((value, index, array) => array.indexOf(value) === index).sort().map((value) => [value, value])}
-            />
+            <ExplorerFiltersForm profile={profile} filters={filters} onFilterChange={onFilterChange} />
           </>
         )}
       </aside>
@@ -342,7 +320,12 @@ export function CategoryExplorerContent({
             <h1>{titleForTab(activeTab)}</h1>
             <p>{isLoading ? "Loading..." : `${entries.length.toLocaleString()} visible results${hasMore ? "+" : ""}`}</p>
           </div>
-          <button className="dn-button dn-button--secondary dn-show-mobile"><Icon name="filter" /> Filters</button>
+          <button
+            className="dn-button dn-button--secondary dn-show-mobile"
+            onClick={() => setIsMobileFiltersOpen(true)}
+          >
+            <Icon name="filter" /> Filters
+          </button>
         </div>
 
         <div className="dn-finding-list">
@@ -368,7 +351,72 @@ export function CategoryExplorerContent({
 
       <FindingInspector finding={selectedEntry} />
       {selectedEntry && isMobileSheetOpen ? <MobileFindingSheet finding={selectedEntry} onClose={onCloseMobileSheet} /> : null}
+      {isMobileFiltersOpen ? (
+        <div className="dn-modal-backdrop" role="presentation" onClick={() => setIsMobileFiltersOpen(false)}>
+          <section
+            className="dn-modal dn-filters-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="filters-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              className="dn-icon-button dn-modal-close"
+              onClick={() => setIsMobileFiltersOpen(false)}
+              aria-label="Close filters"
+            >
+              <Icon name="x" />
+            </button>
+            <h1 id="filters-title">Filters</h1>
+            <div className="dn-filters-modal__actions">
+              <button className="dn-button dn-button--secondary" onClick={onResetFilters}>Reset filters</button>
+            </div>
+            <ExplorerFiltersForm profile={profile} filters={filters} onFilterChange={onFilterChange} />
+            <div className="dn-modal-actions">
+              <button className="dn-button dn-button--primary" onClick={() => setIsMobileFiltersOpen(false)}>Done</button>
+            </div>
+          </section>
+        </div>
+      ) : null}
     </main>
+  );
+}
+
+function ExplorerFiltersForm({
+  profile,
+  filters,
+  onFilterChange,
+}: {
+  profile: ProfileMeta;
+  filters: ExplorerFilters;
+  onFilterChange: <K extends keyof ExplorerFilters>(key: K, value: ExplorerFilters[K]) => void;
+}) {
+  return (
+    <div className="dn-filter-form">
+      <label className="dn-field dn-field--search">
+        <span>Search</span>
+        <div><Icon name="search" /><input value={filters.q} onChange={(event) => onFilterChange("q", event.target.value)} placeholder="Search findings..." /></div>
+      </label>
+      <FilterSelect label="Sort" value={filters.sort} onChange={(value) => onFilterChange("sort", value)} options={[["severity", "Severity / priority"], ["evidence", "Evidence strength"], ["publications", "Publication count"], ["alphabetical", "Alphabetical"]]} />
+      <FilterSelect label="Source" value={filters.source} onChange={(value) => onFilterChange("source", value)} options={optionList(profile.report.facets.sources, "All sources")} />
+      <MultiFilterSelect label="Evidence level" values={filters.evidence} onChange={(value) => onFilterChange("evidence", value)} options={profile.report.facets.evidenceTiers.map((value) => [value, value])} />
+      <MultiFilterSelect
+        label="Clinical significance"
+        values={filters.significance}
+        onChange={(value) => onFilterChange("significance", value)}
+        options={profile.report.facets.clinicalSignificances.map((value) => [value, profile.report.facets.clinicalSignificanceLabels[value] ?? value])}
+      />
+      <MultiFilterSelect label="Repute" values={filters.repute} onChange={(value) => onFilterChange("repute", value)} options={profile.report.facets.reputes.map((value) => [value, value])} />
+      <MultiFilterSelect label="Coverage" values={filters.coverage} onChange={(value) => onFilterChange("coverage", value)} options={profile.report.facets.coverages.map((value) => [value, value])} />
+      <MultiFilterSelect label="Publication bucket" values={filters.publications} onChange={(value) => onFilterChange("publications", value)} options={profile.report.facets.publicationBuckets.map((value) => [value, value])} />
+      <MultiFilterSelect label="Gene" values={filters.gene} onChange={(value) => onFilterChange("gene", value)} options={profile.report.facets.genes.map((value) => [value, value])} />
+      <MultiFilterSelect
+        label="Topic / condition"
+        values={filters.tag}
+        onChange={(value) => onFilterChange("tag", value)}
+        options={[...profile.report.facets.tags, ...profile.report.facets.conditions].filter((value, index, array) => array.indexOf(value) === index).sort().map((value) => [value, value])}
+      />
+    </div>
   );
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -435,11 +435,15 @@ a { color: inherit; }
 .dn-category-screen { display: grid; grid-template-columns: 280px minmax(0, 1fr) minmax(0, 1fr); flex: 1 1 auto; min-height: 0; overflow: hidden; }
 .dn-category-screen.is-filter-collapsed { grid-template-columns: 72px minmax(0, 1fr) minmax(0, 1fr); }
 .dn-filter-sidebar { min-height: 0; overflow: auto; border-right: 1px solid var(--dn-line); padding: 24px; background: rgba(255, 255, 255, 0.45); }
+.dn-filter-form { display: grid; gap: 14px; margin-top: 14px; }
 .dn-filter-heading { display: flex; justify-content: space-between; align-items: center; text-transform: uppercase; letter-spacing: 0.12em; color: var(--dn-muted); font-size: 0.8rem; font-weight: 800; }
 .dn-filter-heading button { background: transparent; color: var(--dn-forest); }
 .dn-filter-heading-actions { display: flex; align-items: center; gap: 10px; }
 .dn-filter-heading-actions .dn-icon-button { width: 34px; min-height: 34px; color: var(--dn-muted); }
 .dn-filter-sidebar.is-collapsed { display: flex; justify-content: center; overflow: hidden; padding: 14px 10px; }
+.dn-filters-modal { width: min(540px, 100%); max-height: 92vh; overflow: auto; }
+.dn-filters-modal h1 { margin: 0; font-family: var(--dn-font-display); color: var(--dn-ink); }
+.dn-filters-modal__actions { display: flex; justify-content: flex-end; margin: 12px 0 18px; }
 .dn-filter-rail-button { width: 100%; min-height: 128px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; border: 1px solid var(--dn-line); border-radius: 14px; background: #fff; color: var(--dn-forest); font-weight: 800; text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.72rem; }
 .dn-filter-rail-button span { writing-mode: vertical-rl; transform: rotate(180deg); }
 .dn-field--search div { position: relative; }


### PR DESCRIPTION
### Motivation
- Improve the mobile explorer experience by removing a non-functional hamburger/menu control and making the Filters button actually expose the filter UI on small screens.
- Keep filter UI consistent between desktop sidebar and mobile modal by reusing the same form markup.

### Description
- Removed the mobile hamburger/menu button from the explorer top bar in `ExplorerShell` so the mobile header is cleaner.
- Implemented a mobile filters modal in `CategoryExplorerContent` using a new `isMobileFiltersOpen` state and backdrop/dismiss/Done controls so the mobile `Filters` button opens a modal with the full filter controls.
- Extracted the filter controls into a shared `ExplorerFiltersForm` component and used it in both the desktop sidebar and the new mobile modal to avoid duplication and keep behavior consistent.
- Added modal/form styles (`.dn-filter-form`, `.dn-filters-modal`, `.dn-filters-modal__actions`) to `src/styles.css` to control spacing and layout for the mobile filters dialog.

### Testing
- Ran `bun run build` and the production build succeeded (`tsc -b` + Vite build) ✅.
- Ran `bun run test` (Vitest): suite executed but there are existing test failures in `src/App.test.tsx` unrelated to the UI changes; the failing tests observed were `appends another page when the user loads more category results`, `hides duplicate finding summaries when the summary matches the title`, and `resets the inspector scroll position when the selected finding changes` ❌.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed461b9c6c83288b2258460952249a)