### PR TITLE
Refine explorer mobile filters and report header styling

### DIFF
--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -84,7 +84,13 @@ export function ExplorerShell({
           <DeanaWordmark compact className="dn-show-mobile" />
           <button className="dn-report-selector" onClick={onBackHome}>
             <Icon name="file" />
-            <span><strong>{report.name}</strong><small>{report.provider} · {report.build} · {report.markerCount.toLocaleString()} markers</small></span>
+            <span>
+              <strong>{report.name}</strong>
+              <small>
+                <span className="dn-report-selector__meta">{report.provider} · {report.build}</span>
+                <span className="dn-report-selector__markers">{report.markerCount.toLocaleString()} markers</span>
+              </small>
+            </span>
           </button>
           <button className="dn-local-status" onClick={() => setModal("privacy")}><Icon name="shield" /> All analysis is local <i /></button>
           <button className="dn-icon-button dn-hide-mobile" aria-label="Help" onClick={() => setModal("help")}><Icon name="help" /></button>
@@ -360,16 +366,18 @@ export function CategoryExplorerContent({
             aria-labelledby="filters-title"
             onClick={(event) => event.stopPropagation()}
           >
-            <button
-              className="dn-icon-button dn-modal-close"
-              onClick={() => setIsMobileFiltersOpen(false)}
-              aria-label="Close filters"
-            >
-              <Icon name="x" />
-            </button>
-            <h1 id="filters-title">Filters</h1>
-            <div className="dn-filters-modal__actions">
-              <button className="dn-button dn-button--secondary" onClick={onResetFilters}>Reset filters</button>
+            <div className="dn-filters-modal__header">
+              <h1 id="filters-title">Filters</h1>
+              <div className="dn-filters-modal__actions">
+                <button className="dn-button dn-button--secondary" onClick={onResetFilters}>Reset filters</button>
+                <button
+                  className="dn-icon-button dn-filters-modal__close"
+                  onClick={() => setIsMobileFiltersOpen(false)}
+                  aria-label="Close filters"
+                >
+                  <Icon name="x" />
+                </button>
+              </div>
             </div>
             <ExplorerFiltersForm profile={profile} filters={filters} onFilterChange={onFilterChange} />
             <div className="dn-modal-actions">

--- a/src/styles.css
+++ b/src/styles.css
@@ -383,9 +383,14 @@ a { color: inherit; }
 .dn-explorer-sidebar.is-collapsed nav button { justify-content: center; padding: 0; }
 .dn-explorer-main { min-width: 0; min-height: 0; height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
 .dn-explorer-topbar { flex: 0 0 auto; height: 78px; border-bottom: 1px solid var(--dn-line); display: flex; align-items: center; gap: 14px; padding: 0 28px; }
-.dn-report-selector { display: inline-flex; align-items: center; gap: 12px; min-width: 320px; border: 1px solid var(--dn-line); background: #fff; border-radius: 12px; padding: 10px 14px; text-align: left; }
-.dn-report-selector span { display: grid; gap: 2px; }
-.dn-report-selector small { color: var(--dn-muted); }
+.dn-report-selector { display: inline-flex; align-items: center; gap: 12px; min-width: 320px; border: 1px solid var(--dn-line); background: linear-gradient(180deg, #fff, #f6f2ea); border-radius: 12px; padding: 10px 14px; text-align: left; color: var(--dn-forest); }
+.dn-report-selector svg { color: var(--dn-clay); }
+.dn-report-selector span { display: grid; gap: 2px; min-width: 0; }
+.dn-report-selector strong { color: var(--dn-forest); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dn-report-selector small { color: var(--dn-muted); display: inline-flex; align-items: center; gap: 6px; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dn-report-selector__meta { overflow: hidden; text-overflow: ellipsis; }
+.dn-report-selector__markers { color: var(--dn-clay-dark); font-weight: 600; }
+.dn-report-selector__markers::before { content: "•"; margin-right: 6px; color: var(--dn-line-strong); }
 .dn-local-status { margin-left: auto; display: inline-flex; align-items: center; gap: 8px; border: 1px solid var(--dn-line); border-radius: 999px; padding: 9px 14px; color: var(--dn-forest); font-weight: 700; }
 .dn-local-status i { width: 8px; height: 8px; border-radius: 50%; background: var(--dn-sage); }
 .dn-export-menu { position: relative; flex: 0 0 auto; }
@@ -443,7 +448,9 @@ a { color: inherit; }
 .dn-filter-sidebar.is-collapsed { display: flex; justify-content: center; overflow: hidden; padding: 14px 10px; }
 .dn-filters-modal { width: min(540px, 100%); max-height: 92vh; overflow: auto; }
 .dn-filters-modal h1 { margin: 0; font-family: var(--dn-font-display); color: var(--dn-ink); }
-.dn-filters-modal__actions { display: flex; justify-content: flex-end; margin: 12px 0 18px; }
+.dn-filters-modal__header { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 18px; padding-top: 2px; }
+.dn-filters-modal__actions { display: inline-flex; align-items: center; justify-content: flex-end; gap: 10px; margin: 0; }
+.dn-filters-modal__close { width: 40px; min-height: 40px; }
 .dn-filter-rail-button { width: 100%; min-height: 128px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; border: 1px solid var(--dn-line); border-radius: 14px; background: #fff; color: var(--dn-forest); font-weight: 800; text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.72rem; }
 .dn-filter-rail-button span { writing-mode: vertical-rl; transform: rotate(180deg); }
 .dn-field--search div { position: relative; }
@@ -582,6 +589,9 @@ a { color: inherit; }
   .dn-explorer-main { display: block; height: auto; min-height: 100vh; overflow: visible; }
   .dn-explorer-topbar { height: auto; padding: 18px; flex-wrap: wrap; }
   .dn-report-selector { min-width: 0; width: 100%; order: 2; }
+  .dn-report-selector small { font-size: 0.86rem; }
+  .dn-report-selector__meta { display: none; }
+  .dn-report-selector__markers::before { content: none; margin-right: 0; }
   .dn-local-status { display: none; }
   .dn-tabbar { padding: 0 18px; gap: 22px; }
   .dn-explorer-actions { padding: 16px 18px 0; display: grid; grid-template-columns: 1fr 1fr; }
@@ -604,4 +614,5 @@ a { color: inherit; }
   .dn-finding-card h2 small { display: block; margin: 3px 0 0; }
   .dn-raw-marker-card { display: grid; }
   .dn-raw-marker-links { justify-content: flex-start; }
+  .dn-filters-modal__header { position: sticky; top: 0; z-index: 2; background: var(--dn-paper); padding-top: 10px; }
 }


### PR DESCRIPTION
### Motivation
- Improve the mobile Explorer UX so the filters modal header spacing and close control avoid top-cropping and the “Reset filters” action is inline with the close button.
- Bring the current-report/header chip in line with branding by adjusting icon/text colors and surface, and make the report name reliably fit (truncate) so it does not wrap to two lines on small viewports while keeping the marker count visible.

### Description
- Split the report selector markup in `src/components/deana/explorer.tsx` so metadata and marker count are separate elements, and force the report name to a single truncated line (`dn-report-selector__meta` / `dn-report-selector__markers`).
- Restyled the report selector in `src/styles.css` (background, icon/text color, truncation rules, marker styling) to match brand tones and improve mobile behaviour.
- Reworked the mobile filters modal header by adding a dedicated `.dn-filters-modal__header` and moving the close control into the header so the `Reset filters` button sits inline with the close button.
- Added responsive rules to hide secondary metadata on narrow screens while keeping the marker count visible, and made the modal header sticky to avoid top-cropping when scrolling.

### Testing
- Ran `bun run build` and the production build completed successfully.
- Ran `bun run test` (Vitest); most suites passed but `src/App.test.tsx` reported 2 failing tests related to finding/inspector flows, so the test run exited with failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed49cf18dc8328ac9faa83e2a9bc1f)