### PR TITLE
Polish mobile inspector tray behavior

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -488,7 +488,7 @@ describe("DeaNA app", () => {
     await screen.findByText("Current report");
     const inspector = await screen.findByLabelText("Finding inspector");
 
-    expect(within(inspector).getByRole("heading", { name: "Duplicate finding title" })).toBeInTheDocument();
+    expect(await within(inspector).findByRole("heading", { name: "Duplicate finding title" })).toBeInTheDocument();
     expect(inspector.querySelector(".dn-inspector__intro")).toBeNull();
     expect(within(inspector).getByText("The detail remains visible even when the summary is redundant.")).toBeInTheDocument();
   });
@@ -503,7 +503,7 @@ describe("DeaNA app", () => {
     const inspector = await screen.findByLabelText("Finding inspector");
     inspector.scrollTop = 120;
 
-    await user.click(screen.getByRole("button", { name: /Medical finding 02/i }));
+    await user.click(await screen.findByRole("button", { name: /Medical finding 02/i }));
 
     await waitFor(() =>
       expect(screen.getByTestId("location").textContent).toContain("selected=medical-2"),

--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -480,12 +480,44 @@ function FindingInspector({ finding }: { finding: StoredReportEntry | null }) {
 }
 
 function MobileFindingSheet({ finding, onClose }: { finding: StoredReportEntry; onClose: () => void }) {
+  const [isVisible, setIsVisible] = useState(false);
+  const closeTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const frameId = window.requestAnimationFrame(() => setIsVisible(true));
+    return () => window.cancelAnimationFrame(frameId);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current !== null) {
+        window.clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  function handleClose() {
+    if (closeTimeoutRef.current !== null) return;
+    setIsVisible(false);
+    closeTimeoutRef.current = window.setTimeout(() => {
+      onClose();
+      closeTimeoutRef.current = null;
+    }, 180);
+  }
+
   return (
-    <section className="dn-mobile-sheet" role="dialog" aria-modal="true" aria-labelledby="mobile-finding-title">
-      <div className="dn-sheet-handle" />
-      <button className="dn-icon-button dn-modal-close" aria-label="Close" onClick={onClose}><Icon name="x" /></button>
-      <FindingDetailContent finding={finding} titleId="mobile-finding-title" titleLevel="h1" />
-    </section>
+    <div className="dn-mobile-sheet-backdrop" role="presentation" onClick={handleClose}>
+      <section
+        className={`dn-mobile-sheet ${isVisible ? "is-visible" : ""}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mobile-finding-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button className="dn-icon-button dn-modal-close" aria-label="Close" onClick={handleClose}><Icon name="x" /></button>
+        <FindingDetailContent finding={finding} titleId="mobile-finding-title" titleLevel="h1" />
+      </section>
+    </div>
   );
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -509,6 +509,7 @@ a { color: inherit; }
 .dn-empty-state h2 { color: var(--dn-forest); font-family: var(--dn-font-display); margin: 0 0 8px; }
 .dn-result-footer { margin-top: 18px; text-align: center; }
 
+.dn-mobile-sheet-backdrop { display: none; }
 .dn-mobile-sheet { display: none; }
 .dn-raw-screen { grid-template-columns: 1fr; }
 .dn-raw-list-panel { grid-column: 1 / -1; }
@@ -528,13 +529,17 @@ a { color: inherit; }
 @media (max-width: 1100px) {
   .dn-category-screen { grid-template-columns: 260px minmax(0, 1fr); }
   .dn-inspector { display: none; }
-  .dn-mobile-sheet { display: block; position: fixed; left: 0; right: 0; bottom: 0; z-index: 40; max-height: min(82vh, 680px); overflow: auto; overscroll-behavior: contain; background: var(--dn-paper); border: 1px solid var(--dn-line); border-bottom: 0; border-radius: 28px 28px 0 0; box-shadow: var(--dn-shadow); padding: 26px 20px 20px; }
-  .dn-sheet-handle { width: 64px; height: 5px; border-radius: 999px; background: var(--dn-line-strong); margin: 0 auto 18px; }
+  .dn-mobile-sheet-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; align-items: flex-end; justify-content: center; background: rgba(29, 27, 24, 0.56); backdrop-filter: blur(10px); }
+  .dn-mobile-sheet { display: block; width: 100%; max-height: min(82vh, 680px); overflow: auto; overscroll-behavior: contain; background: var(--dn-paper); border: 1px solid var(--dn-line); border-bottom: 0; border-radius: 28px 28px 0 0; box-shadow: var(--dn-shadow); padding: 26px 20px 20px; transform: translateY(28px); opacity: 0; transition: transform 180ms ease, opacity 180ms ease; }
+  .dn-mobile-sheet.is-visible { transform: translateY(0); opacity: 1; }
   .dn-mobile-sheet h1 { font-family: var(--dn-font-display); color: var(--dn-ink); font-size: 1.8rem; margin: 0 48px 8px 0; }
   .dn-mobile-sheet h2,
   .dn-mobile-sheet h3 { font-size: 0.95rem; margin: 18px 0 6px; color: var(--dn-ink); }
   .dn-mobile-sheet p,
   .dn-mobile-sheet li { color: var(--dn-muted); line-height: 1.5; }
+  @media (prefers-reduced-motion: reduce) {
+    .dn-mobile-sheet { transition: none; }
+  }
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
### Motivation

- The mobile finding tray should behave like a modal with a blurred backdrop when open to focus content and match existing modal styling.
- The top drag handle should be removed to simplify the visual chrome for the tray.
- The tray should animate on open and close so transitions feel smoother on mobile.

### Description

- Wrapped the mobile sheet in a backdrop and made backdrop taps close the tray by adding a `dn-mobile-sheet-backdrop` wrapper and wiring a close handler in `MobileFindingSheet` (`src/components/deana/explorer.tsx`).
- Removed the sheet handle and stopped rendering it, and made clicks inside the sheet call `event.stopPropagation()` so only backdrop taps close the tray (`src/components/deana/explorer.tsx`).
- Added `is-visible` state, `requestAnimationFrame` on mount, and a short timeout on close so the sheet can animate out before unmounting, and guarded timeouts on unmount (`src/components/deana/explorer.tsx`).
- Introduced backdrop blur, dark overlay, and enter/exit transitions plus a `prefers-reduced-motion` fallback in `src/styles.css` and updated sheet positioning and z-index to match modal behavior (`src/styles.css`).
- Updated two tests to wait for asynchronously rendered elements affected by the transition timing by switching to `findByRole`/`findBy*` where needed (`src/App.test.tsx`).

### Testing

- Ran the test suite with `bun run test`, fixed timing-related test failures by making assertions await the rendered elements, and re-ran `bun run test` until all tests passed.
- Final test run: `vitest` reports all tests passing (`29 tests` across `7` test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4adabca48328a26dda8bc5ed6c86)