### PR TITLE
Remove mobile inspector tray animation

### DIFF
--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -480,35 +480,14 @@ function FindingInspector({ finding }: { finding: StoredReportEntry | null }) {
 }
 
 function MobileFindingSheet({ finding, onClose }: { finding: StoredReportEntry; onClose: () => void }) {
-  const [isVisible, setIsVisible] = useState(false);
-  const closeTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    const frameId = window.requestAnimationFrame(() => setIsVisible(true));
-    return () => window.cancelAnimationFrame(frameId);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (closeTimeoutRef.current !== null) {
-        window.clearTimeout(closeTimeoutRef.current);
-      }
-    };
-  }, []);
-
   function handleClose() {
-    if (closeTimeoutRef.current !== null) return;
-    setIsVisible(false);
-    closeTimeoutRef.current = window.setTimeout(() => {
-      onClose();
-      closeTimeoutRef.current = null;
-    }, 180);
+    onClose();
   }
 
   return (
     <div className="dn-mobile-sheet-backdrop" role="presentation" onClick={handleClose}>
       <section
-        className={`dn-mobile-sheet ${isVisible ? "is-visible" : ""}`}
+        className="dn-mobile-sheet"
         role="dialog"
         aria-modal="true"
         aria-labelledby="mobile-finding-title"

--- a/src/styles.css
+++ b/src/styles.css
@@ -530,16 +530,12 @@ a { color: inherit; }
   .dn-category-screen { grid-template-columns: 260px minmax(0, 1fr); }
   .dn-inspector { display: none; }
   .dn-mobile-sheet-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; align-items: flex-end; justify-content: center; background: rgba(29, 27, 24, 0.56); backdrop-filter: blur(10px); }
-  .dn-mobile-sheet { display: block; width: 100%; max-height: min(82vh, 680px); overflow: auto; overscroll-behavior: contain; background: var(--dn-paper); border: 1px solid var(--dn-line); border-bottom: 0; border-radius: 28px 28px 0 0; box-shadow: var(--dn-shadow); padding: 26px 20px 20px; transform: translateY(28px); opacity: 0; transition: transform 180ms ease, opacity 180ms ease; }
-  .dn-mobile-sheet.is-visible { transform: translateY(0); opacity: 1; }
+  .dn-mobile-sheet { display: block; width: 100%; max-height: min(82vh, 680px); overflow: auto; overscroll-behavior: contain; background: var(--dn-paper); border: 1px solid var(--dn-line); border-bottom: 0; border-radius: 28px 28px 0 0; box-shadow: var(--dn-shadow); padding: 26px 20px 20px; }
   .dn-mobile-sheet h1 { font-family: var(--dn-font-display); color: var(--dn-ink); font-size: 1.8rem; margin: 0 48px 8px 0; }
   .dn-mobile-sheet h2,
   .dn-mobile-sheet h3 { font-size: 0.95rem; margin: 18px 0 6px; color: var(--dn-ink); }
   .dn-mobile-sheet p,
   .dn-mobile-sheet li { color: var(--dn-muted); line-height: 1.5; }
-  @media (prefers-reduced-motion: reduce) {
-    .dn-mobile-sheet { transition: none; }
-  }
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
### Motivation
- The mobile inspector sheet currently animates on show/hide and waits for a transition to finish before unmounting, which introduces unnecessary delay and lifecycle complexity for a small UI change.
- The change simplifies behavior to immediately show/hide the mobile tray and matches user preference to remove the animation on mobile.

### Description
- Remove the `isVisible` enter/exit state and the close timeout logic from `MobileFindingSheet` in `src/components/deana/explorer.tsx` so the sheet no longer toggles an animated visibility class and closes immediately via `onClose()`.
- Remove the transform/opacity transition and the `.dn-mobile-sheet.is-visible` rules from `src/styles.css`, leaving the mobile sheet rendered without animation styles.
- Remove the `prefers-reduced-motion` transition override since transitions were removed.

### Testing
- Ran the test suite with `bun run test` and all tests passed (7 test files, 29 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4cf9f7bc83289e09ba57ba762cd6)