### PR TITLE
Make explorer tab bar sticky on scroll

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -397,7 +397,7 @@ a { color: inherit; }
 .dn-export-menu__panel { position: absolute; right: 0; top: calc(100% + 10px); z-index: 20; display: grid; gap: 6px; min-width: 210px; padding: 8px; border: 1px solid var(--dn-line); border-radius: 14px; background: var(--dn-paper); box-shadow: var(--dn-shadow-soft); }
 .dn-export-menu__panel button { display: flex; align-items: center; gap: 10px; min-height: 42px; padding: 0 12px; border-radius: 10px; background: transparent; color: var(--dn-ink); text-align: left; }
 .dn-export-menu__panel button:hover { background: var(--dn-mint); color: var(--dn-forest); }
-.dn-tabbar { flex: 0 0 auto; display: flex; align-items: center; gap: 26px; padding: 0 28px; height: 58px; border-bottom: 1px solid var(--dn-line); overflow-x: auto; }
+.dn-tabbar { flex: 0 0 auto; display: flex; align-items: center; gap: 26px; padding: 0 28px; height: 58px; border-bottom: 1px solid var(--dn-line); overflow-x: auto; position: sticky; top: 0; z-index: 12; background: var(--dn-paper); }
 .dn-tabbar button { border-bottom: 2px solid transparent; background: transparent; height: 58px; color: var(--dn-muted); white-space: nowrap; }
 .dn-tabbar button.is-active { color: var(--dn-forest); border-color: var(--dn-forest); font-weight: 700; }
 .dn-explorer-actions { flex: 0 0 auto; display: flex; justify-content: flex-end; gap: 12px; padding: 18px 28px 0; }


### PR DESCRIPTION
### Motivation
- Keep the Explorer section tabs visible while the user scrolls so navigation remains accessible by pinning the tab bar to the top of the viewport.

### Description
- Update `src/styles.css` to make `.dn-tabbar` `position: sticky` with `top: 0`, an explicit `z-index`, and a `background` color so the tab bar remains pinned and readable above scrolling content.

### Testing
- Ran `bun run build` which completed successfully; ran `bun run test` which exercised the test suite but one existing UI test (`appends another page when the user loads more category results`) failed and is unrelated to this CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4dca33b48328b30ab4feddd57397)