### PR TITLE
Adjust mobile explorer overview cards

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -603,6 +603,13 @@ a { color: inherit; }
   .dn-overview-metrics .dn-overview-metric:last-child { grid-column: 1 / -1; }
   .dn-category-jump-card,
   .dn-overview-two-col { margin-inline: 18px; padding-inline: 0; }
+  .dn-category-jump-card {
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
+  }
   .dn-overview-two-col { display: grid; padding: 0 18px; }
   .dn-category-card p { min-height: 0; }
   .dn-category-screen { display: block; min-height: auto; overflow: visible; }


### PR DESCRIPTION
### Motivation
- On small screens the “Start with the strongest signal” wrapper should not show a framed background or border so the category cards align flush with the surrounding overview sections.

### Description
- Update mobile styles in `src/styles.css` to add rules for `.dn-category-jump-card` under the `@media (max-width: 980px)` breakpoint, setting `background: transparent`, `border: 0`, `box-shadow: none`, `border-radius: 0`, and `padding: 0` so the section is flush with other overview content.

### Testing
- Ran the production build with `bun run build` (which runs `tsc -b` and `vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4ff5724483289960dc6e6f163468)