### PR TITLE
Align overview cards on mobile

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -610,7 +610,7 @@ a { color: inherit; }
     border-radius: 0;
     padding: 0;
   }
-  .dn-overview-two-col { display: grid; padding: 0 18px; }
+  .dn-overview-two-col { display: grid; padding: 0; }
   .dn-category-card p { min-height: 0; }
   .dn-category-screen { display: block; min-height: auto; overflow: visible; }
   .dn-filter-sidebar { display: none; }


### PR DESCRIPTION
### Motivation
- Make the overview section cards the same width as the category cards on small screens by removing extra mobile-only horizontal padding so mobile layout elements align.

### Description
- CSS-only change in `src/styles.css`: in the `@media (max-width: 980px)` block update `.dn-overview-two-col` from `padding: 0 18px;` to `padding: 0;` so overview columns match surrounding card widths.

### Testing
- Ran `bun run test` and the Vitest suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed524625c4832895519796a94e379c)