### PR TITLE
Remove homepage How Deana works button

### DIFF
--- a/src/components/deana/marketing.tsx
+++ b/src/components/deana/marketing.tsx
@@ -76,14 +76,12 @@ export function MarketingReturning({
   onOpenReport,
   onRemoveReport,
   onPrivacy,
-  onHowItWorks,
 }: {
   reports: SavedReportCard[];
   onCreateNew?: () => void;
   onOpenReport?: (id: string) => void;
   onRemoveReport?: (id: string) => void;
   onPrivacy?: () => void;
-  onHowItWorks?: () => void;
 }) {
   return (
     <main className="dn-marketing-shell dn-marketing-shell--returning">
@@ -104,7 +102,6 @@ export function MarketingReturning({
         </p>
         <div className="dn-hero-actions">
           <button className="dn-button dn-button--primary dn-button--large" onClick={onCreateNew}><Icon name="plus" /> Create new report</button>
-          <button className="dn-button dn-button--secondary dn-button--large" onClick={onHowItWorks}><Icon name="help" /> How Deana works</button>
         </div>
       </section>
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -94,10 +94,6 @@ export function HomeScreen({
     navigate("/processing");
   }
 
-  function scrollHowItWorks() {
-    document.getElementById("how-it-works")?.scrollIntoView({ behavior: "smooth", block: "start" });
-  }
-
   const reportCards = profiles.map(toReportCard);
 
   return (
@@ -114,7 +110,6 @@ export function HomeScreen({
           onOpenReport={(id) => navigate(`/explorer/${id}?tab=overview`)}
           onRemoveReport={(id) => void removeProfile(id)}
           onPrivacy={() => setShowPrivacy(true)}
-          onHowItWorks={scrollHowItWorks}
         />
       )}
 


### PR DESCRIPTION
### Motivation
- The returning-user homepage hero included a secondary “How Deana works” CTA that was visible on mobile and should be removed to simplify the hero actions.

### Description
- Removed the secondary "How Deana works" button from the `MarketingReturning` hero action row in `src/components/deana/marketing.tsx`.
- Dropped the now-unused `onHowItWorks` callback from the `MarketingReturning` props and its type signature.
- Removed the `scrollHowItWorks` handler and the `onHowItWorks` prop wiring from `src/screens/HomeScreen.tsx`.
- Updated usages so the returning homepage only shows the primary "Create new report" action.

### Testing
- Ran the test suite with `bun run test`, which executed the Vitest suite and completed successfully with all tests passing (29 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed579dca148328b7c4370243063bd5)