### PR TITLE
Clip botanical background and add markdown rendering to inspector

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -493,6 +493,29 @@ describe("DeaNA app", () => {
     expect(within(inspector).getByText("The detail remains visible even when the summary is redundant.")).toBeInTheDocument();
   });
 
+  it("renders markdown formatting in the inspector content", async () => {
+    const profile = makePaginatedProfile("profile-10", 1);
+    storedProfiles = [{
+      ...profile,
+      report: {
+        ...profile.report,
+        entries: profile.report.entries.map((entry) => ({
+          ...entry,
+          summary: "**Important** marker summary.",
+          detail: "Use `rsid` details.\n- First bullet\n- [Source detail](https://example.com)",
+        })),
+      },
+    }];
+
+    renderApp("/explorer/profile-10?tab=medical&selected=medical-1");
+
+    await screen.findByText("Current report");
+    expect((await screen.findAllByText("Important", { selector: "strong" })).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("rsid", { selector: "code" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("First bullet").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Source detail" })[0]).toHaveAttribute("href", "https://example.com");
+  });
+
   it("resets the inspector scroll position when the selected finding changes", async () => {
     const user = userEvent.setup();
     storedProfiles = [makePaginatedProfile("profile-7", 3)];

--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -517,30 +517,30 @@ function FindingDetailContent({
       <p className="dn-eyebrow">Inspector</p>
       <Title id={titleId}>{finding.title}</Title>
       <span className={`dn-priority-pill dn-finding-tone-${toneForEntry(finding)}`}>{priorityLabel(finding)}</span>
-      {summary ? <p className="dn-inspector__intro">{summary}</p> : null}
+      {summary ? <div className="dn-inspector__intro">{renderMarkdown(summary)}</div> : null}
       {finding.detail.trim() ? (
         <section>
           <h3>Details</h3>
-          <p>{finding.detail}</p>
+          {renderMarkdown(finding.detail)}
         </section>
       ) : null}
       <section>
         <h3>Genotype found</h3>
-        <p>{finding.genotypeSummary}</p>
+        {renderMarkdown(finding.genotypeSummary)}
       </section>
       <section>
         <h3>Why it matters</h3>
-        <p>{finding.whyItMatters}</p>
+        {renderMarkdown(finding.whyItMatters)}
       </section>
       <section>
         <h3>Confidence / evidence</h3>
-        <p>{finding.confidenceNote}</p>
+        {renderMarkdown(finding.confidenceNote)}
       </section>
       {finding.warnings.length > 0 ? (
         <section>
           <h3>Warnings</h3>
           <ul>
-            {finding.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+            {finding.warnings.map((warning) => <li key={warning}>{renderMarkdownInline(warning)}</li>)}
           </ul>
         </section>
       ) : null}
@@ -560,7 +560,7 @@ function FindingDetailContent({
         <section>
           <h3>Source details</h3>
           <ul>
-            {finding.sourceNotes.map((note) => <li key={note}>{note}</li>)}
+            {finding.sourceNotes.map((note) => <li key={note}>{renderMarkdownInline(note)}</li>)}
           </ul>
         </section>
       ) : null}
@@ -568,6 +568,102 @@ function FindingDetailContent({
       <div className="dn-callout dn-callout--success"><Icon name="lock" /> Private by design. Your DNA stays on this device.</div>
     </>
   );
+}
+
+function renderMarkdown(value: string): ReactNode {
+  const normalized = value.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return null;
+
+  const lines = normalized.split("\n");
+  const blocks: ReactNode[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index].trim();
+    if (!line) {
+      index += 1;
+      continue;
+    }
+
+    const unorderedMatch = /^[-*]\s+(.+)$/.exec(line);
+    if (unorderedMatch) {
+      const items: ReactNode[] = [];
+      while (index < lines.length) {
+        const itemLine = lines[index].trim();
+        const itemMatch = /^[-*]\s+(.+)$/.exec(itemLine);
+        if (!itemMatch) break;
+        items.push(<li key={`markdown-li-${index}`}>{renderMarkdownInline(itemMatch[1])}</li>);
+        index += 1;
+      }
+      blocks.push(<ul key={`markdown-ul-${index}`}>{items}</ul>);
+      continue;
+    }
+
+    const orderedMatch = /^(\d+)\.\s+(.+)$/.exec(line);
+    if (orderedMatch) {
+      const items: ReactNode[] = [];
+      while (index < lines.length) {
+        const itemLine = lines[index].trim();
+        const itemMatch = /^(\d+)\.\s+(.+)$/.exec(itemLine);
+        if (!itemMatch) break;
+        items.push(<li key={`markdown-ol-li-${index}`}>{renderMarkdownInline(itemMatch[2])}</li>);
+        index += 1;
+      }
+      blocks.push(<ol key={`markdown-ol-${index}`}>{items}</ol>);
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+    while (index < lines.length) {
+      const paragraphLine = lines[index].trim();
+      if (!paragraphLine) break;
+      if (/^[-*]\s+/.test(paragraphLine) || /^\d+\.\s+/.test(paragraphLine)) break;
+      paragraphLines.push(paragraphLine);
+      index += 1;
+    }
+    blocks.push(<p key={`markdown-p-${index}`}>{renderMarkdownInline(paragraphLines.join(" "))}</p>);
+  }
+
+  return blocks;
+}
+
+function renderMarkdownInline(value: string): ReactNode {
+  const nodes: ReactNode[] = [];
+  const pattern = /(\[[^\]]+\]\([^)]+\)|`[^`]+`|\*\*[^*]+\*\*|__[^_]+__|\*[^*]+\*|_[^_]+_)/g;
+  let lastIndex = 0;
+
+  for (const match of value.matchAll(pattern)) {
+    const token = match[0];
+    const tokenIndex = match.index ?? 0;
+    if (tokenIndex > lastIndex) {
+      nodes.push(value.slice(lastIndex, tokenIndex));
+    }
+
+    if (token.startsWith("[") && token.includes("](") && token.endsWith(")")) {
+      const label = token.slice(1, token.indexOf("]("));
+      const url = token.slice(token.indexOf("](") + 2, -1).trim();
+      nodes.push(
+        <a key={`${tokenIndex}-${url}`} href={url} target="_blank" rel="noreferrer">
+          {label}
+        </a>,
+      );
+    } else if ((token.startsWith("**") && token.endsWith("**")) || (token.startsWith("__") && token.endsWith("__"))) {
+      nodes.push(<strong key={tokenIndex}>{token.slice(2, -2)}</strong>);
+    } else if ((token.startsWith("*") && token.endsWith("*")) || (token.startsWith("_") && token.endsWith("_"))) {
+      nodes.push(<em key={tokenIndex}>{token.slice(1, -1)}</em>);
+    } else if (token.startsWith("`") && token.endsWith("`")) {
+      nodes.push(<code key={tokenIndex}>{token.slice(1, -1)}</code>);
+    } else {
+      nodes.push(token);
+    }
+    lastIndex = tokenIndex + token.length;
+  }
+
+  if (lastIndex < value.length) {
+    nodes.push(value.slice(lastIndex));
+  }
+
+  return nodes.length > 0 ? nodes : value;
 }
 
 function FilterSelect({

--- a/src/styles.css
+++ b/src/styles.css
@@ -149,7 +149,7 @@ a { color: inherit; }
 }
 .dn-marketing-header { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 34px; }
 .dn-header-actions { display: flex; align-items: center; gap: 10px; }
-.dn-botanical-card { position: relative; isolation: isolate; }
+.dn-botanical-card { position: relative; isolation: isolate; overflow: hidden; }
 .dn-hero,
 .dn-processing-hero { text-align: center; padding: 34px 120px 22px; }
 .dn-hero h1,
@@ -502,6 +502,10 @@ a { color: inherit; }
 .dn-inspector p,
 .dn-inspector li { color: var(--dn-muted); line-height: 1.6; }
 .dn-inspector h3 { margin: 22px 0 8px; color: var(--dn-ink); }
+.dn-inspector ul,
+.dn-inspector ol { margin: 8px 0 0; padding-left: 1.2rem; }
+.dn-inspector a { color: var(--dn-forest-2); text-decoration: underline; text-underline-offset: 3px; }
+.dn-inspector code { font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace; background: rgba(29, 27, 24, 0.08); border-radius: 6px; padding: 0.08em 0.36em; }
 .dn-source-link-list { display: grid; gap: 8px; }
 .dn-source-link-list a { display: grid; grid-template-columns: 1fr auto 20px; gap: 8px; align-items: center; text-align: left; border: 1px solid var(--dn-line); border-radius: 12px; background: #fff; padding: 12px; color: var(--dn-ink); text-decoration: none; }
 .dn-source-link-list small { color: var(--dn-muted); }


### PR DESCRIPTION
### Motivation

- Prevent decorative botanical background accents from visually bleeding over adjacent cards (e.g. recent reports, processing) by ensuring those decorative layers are clipped to their card container.
- Improve the inspector experience by allowing richer, Markdown-style content (lists, links, emphasis, inline code) in summary/details/confidence/warnings/source notes instead of raw plain text.

### Description

- Clip botanical decorations by adding `overflow: hidden` to `.dn-botanical-card` so background accents cannot overflow card bounds (`src/styles.css`).
- Implement simple Markdown rendering helpers `renderMarkdown` and `renderMarkdownInline` and use them in the inspector to render `summary`, `detail`, `genotypeSummary`, `whyItMatters`, `confidenceNote`, `warnings`, and `sourceNotes` with support for paragraphs, unordered/ordered lists, links, bold, italic, and inline code (`src/components/deana/explorer.tsx`).
- Update inspector markup to insert rendered nodes (replacing plain `<p>` usage) and render warnings/source notes via the inline renderer to preserve list/inline formatting (`src/components/deana/explorer.tsx`).
- Add presentation styles for inspector lists, links, and inline code to match the existing UI (`src/styles.css`).
- Add a test that verifies inspector Markdown rendering (bold, inline code, list item, and link) to guard the behavior (`src/App.test.tsx`).

### Testing

- Ran the unit test suite with `bun run test` (Vitest); all tests passed: `30 passed (30)`.
- Built the production bundle with `bun run build` (`tsc -b && vite build`); build completed successfully with generated assets.
- Verified the new inspector rendering visually via the test assertions for bold, code, list, and link tokens in the inspector (automated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed58f6658c83289473d0a4d511d2b1)