### PR TITLE
Follow-up: trim oversized AI chat message history before validation

### DIFF
--- a/api/chat.test.ts
+++ b/api/chat.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { trimMessagesToRecentWindow } from "./chat";
+
+function buildMessages(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `m-${index}`,
+    role: index % 2 === 0 ? "user" : "assistant",
+    parts: [{ type: "text", text: `message-${index}` }],
+  }));
+}
+
+describe("trimMessagesToRecentWindow", () => {
+  it("keeps payload unchanged when messages are at or under max", () => {
+    const payload = {
+      consent: { accepted: true, version: "v1" },
+      context: { contextVersion: "v1" },
+      messages: buildMessages(12),
+    };
+
+    expect(trimMessagesToRecentWindow(payload)).toEqual(payload);
+  });
+
+  it("trims to the most recent message window", () => {
+    const payload = {
+      consent: { accepted: true, version: "v1" },
+      context: { contextVersion: "v1" },
+      messages: buildMessages(16),
+    };
+
+    expect(trimMessagesToRecentWindow(payload)).toEqual({
+      ...payload,
+      messages: payload.messages.slice(-12),
+    });
+  });
+
+  it("ignores non-object payloads", () => {
+    expect(trimMessagesToRecentWindow(null)).toBeNull();
+    expect(trimMessagesToRecentWindow("not-an-object")).toBe("not-an-object");
+  });
+});

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -132,6 +132,21 @@ const chatRequestSchema = z.object({
   messages: z.array(uiMessageSchema).min(1).max(MAX_MESSAGES),
 });
 
+export function trimMessagesToRecentWindow(body: unknown): unknown {
+  if (!body || typeof body !== "object" || !("messages" in body)) {
+    return body;
+  }
+  const candidate = body as Record<string, unknown>;
+  const messages = candidate.messages;
+  if (!Array.isArray(messages) || messages.length <= MAX_MESSAGES) {
+    return body;
+  }
+  return {
+    ...candidate,
+    messages: messages.slice(-MAX_MESSAGES),
+  };
+}
+
 function jsonResponse(status: number, message: string): Response {
   return Response.json({ error: message }, { status });
 }
@@ -215,7 +230,8 @@ export default async function handler(request: Request): Promise<Response> {
     return jsonResponse(400, "Invalid JSON body.");
   }
 
-  const parsed = chatRequestSchema.safeParse(body);
+  const trimmedBody = trimMessagesToRecentWindow(body);
+  const parsed = chatRequestSchema.safeParse(trimmedBody);
   if (!parsed.success) {
     return jsonResponse(400, "Invalid chat request.");
   }


### PR DESCRIPTION
### Motivation
- Prevent normal conversations from hard-failing with `400 Invalid chat request` when the client forwards full thread history by trimming oversized `messages` before schema validation. 
- Preserve existing server-side guards while making long-running chats usable without changing client behavior. 

### Description
- Added an exported helper `trimMessagesToRecentWindow` in `api/chat.ts` that truncates `messages` to the latest `MAX_MESSAGES` (12) when the incoming payload exceeds the limit. 
- Apply `trimMessagesToRecentWindow` to the parsed request body before calling `chatRequestSchema.safeParse`, so validation runs against the normalized recent-window payload. 
- Kept the schema `max(MAX_MESSAGES)` guard in place to validate the trimmed payload. 
- Added unit tests in `api/chat.test.ts` covering unchanged payloads (<=12), trimming behavior (>12), and non-object passthrough. 

### Testing
- Ran `bun run test api/chat.test.ts`, which passed (3 tests). 
- Ran `bun run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4c08590083288bf0757bff61b67d)