### PR TITLE
Document curated records, strand orientation, and shard update pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,33 @@ Do not add non-local AI tools. The `searchReportFindings` tool is a planner only
 
 Keep `.evidence-cache`, generated seed/bulk candidate JSON, and local DNA files out of git. Keep `public/evidence-packs` tracked because the deployed static app serves those files directly.
 
+### Curated Records (`records.json`)
+
+`public/evidence-packs/<version>/records.json` is a hand-maintained seed layer. The build script loads it first before ClinVar, GWAS, and SNPedia bulk records; curated records take precedence when IDs collide. It is **not** auto-generated — changes must be made manually.
+
+When editing a curated record's `riskAllele` or any other field, three files must be updated together:
+
+1. Edit `records.json`.
+2. Find the correct shard: `rsid_numeric % 256` gives the bucket (e.g. rs6025 → 6025 % 256 = 137 → `shards/m137.json`).
+3. Apply the same change to the matching record in the shard file.
+4. Recalculate the shard's SHA-256 and update `manifest.json` under that shard's `recordsSha256` entry.
+
+The browser validates every shard's content against the manifest checksum on load; a mismatch causes a hard error.
+
+### Strand Orientation in Evaluate Functions
+
+Consumer DNA arrays (AncestryDNA, 23andMe) frequently report SNPs on the minus strand. A SNP with plus-strand alleles G/A (risk allele A) appears as C/T (risk allele T) in minus-strand files. Evaluate functions in `src/lib/evidencePack.ts` must handle both orientations.
+
+For SNPs where the risk allele is A on the plus strand and T on the minus strand, count both:
+
+```typescript
+const riskCount = genotype ? [...genotype].filter((a) => a === "A" || a === "T").length : 0;
+```
+
+For the `riskAllele` field in curated records, use the minus-strand allele (e.g. `"T"` for rs6025 and rs1799963) because consumer arrays predominantly report those SNPs on the minus strand.
+
+SNPedia records store plus-strand genotypes parsed from page titles. `markerMatchesRecord` in `evidencePackData.ts` checks both the stored genotype and its Watson-Crick complement, so minus-strand user data matches automatically. Do **not** add complement checking to the `riskAllele` branch — the complement of a risk allele can equal the reference allele for some SNPs, causing false positives on reference-homozygous users.
+
 ## Coding Style & Naming Conventions
 
 Write strict TypeScript and React function components. Use 2-space indentation, double quotes, semicolons, and named exports for reusable modules, matching the existing code. Components and screens use `PascalCase` file names, for example `HomeScreen.tsx`; library modules use lower camel case, for example `reportEngine.ts`; workers use the `.worker.ts` suffix.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ That command downloads large NCBI dbSNP VCFs into `.evidence-cache/dbsnp`, maps 
 
 Source caches are written under `.evidence-cache`, which is intentionally ignored. Generated candidate dumps under `docs/evidence-candidates` are also ignored. The shipped static pack in `public/evidence-packs` is tracked because the browser app serves it directly.
 
+`public/evidence-packs/<version>/records.json` is a hand-maintained curated seed layer loaded by the build script before bulk ClinVar, GWAS, and SNPedia records. It contains high-priority entries (specific ClinVar variants, CPIC pharmacogenomics records, and curated associations) that the automated pipeline does not produce in the correct form. When editing a curated record's fields, the corresponding shard file and the shard's SHA-256 in `manifest.json` must be updated to match — see `AGENTS.md` for the three-file update pattern.
+
 GWAS sync is optional unless a current association export URL is supplied. The sync script accepts the current GWAS Catalog ZIP release and extracts the associations TSV into `.evidence-cache/gwas/associations.tsv`:
 
 ```bash
@@ -203,4 +205,4 @@ See [LICENSE.md](LICENSE.md) and [NOTICE](NOTICE) for full terms and attribution
 
 ## Medical Disclaimer
 
-Deana is informational software. It is not medical advice, diagnosis, or treatment. Consumer raw DNA arrays can miss clinically important variants, can include strand/build differences, and should not be used for clinical decisions without qualified review and confirmatory testing.
+Deana is informational software. It is not medical advice, diagnosis, or treatment. Consumer raw DNA arrays can miss clinically important variants, report alleles on the minus strand (requiring strand-aware interpretation), and should not be used for clinical decisions without qualified review and confirmatory testing.


### PR DESCRIPTION
## Summary

- Documents the `records.json` curated seed layer — explains it is hand-maintained, not auto-generated, and that changes require a three-file update (records.json → shard file → manifest SHA-256)
- Documents the strand orientation pattern for `evaluate` functions: consumer arrays often report on the minus strand, so functions must count both A and T alleles rather than assuming a single strand
- Documents why `markerMatchesRecord` checks the Watson-Crick complement for `record.genotype` matches (SNPedia) but intentionally does not for the `riskAllele` branch (false-positive risk)
- Updates the medical disclaimer in README to explicitly name minus-strand reporting rather than the previous vague "strand/build differences"

## Files changed

- `AGENTS.md` — two new subsections under Evidence Pack Workflow: Curated Records and Strand Orientation in Evaluate Functions
- `README.md` — paragraph added under Evidence Packs explaining the curated seed layer; medical disclaimer updated

https://claude.ai/code/session_01HBW4xrGjN7qqGV52XdaPEF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBW4xrGjN7qqGV52XdaPEF)_