### PR TITLE
Add model-fallback runner, local search index, and caching for AI chat/title generation

### DIFF
--- a/api/chat-title.ts
+++ b/api/chat-title.ts
@@ -1,8 +1,9 @@
 import { createGateway } from "@ai-sdk/gateway";
-import { generateText } from "ai";
 import { z } from "zod";
 import { getGatewayApiKey, isSameOrigin } from "../src/lib/aiGatewayAuth";
-import { buildGatewayProviderOptions, DEFAULT_DEANA_LLM_MODEL, formatChatTitle } from "../src/lib/aiChat";
+import { buildGatewayProviderOptions, formatChatTitle } from "../src/lib/aiChat";
+import { TASK_MODELS } from "../src/lib/ai/models";
+import { runTextWithFallback } from "../src/lib/ai/run-with-fallback";
 
 declare const process: {
   env: Record<string, string | undefined>;
@@ -13,7 +14,6 @@ export const config = {
 };
 
 const MAX_BODY_BYTES = 3_000;
-const selectedModel = process.env.DEANA_LLM_MODEL ?? DEFAULT_DEANA_LLM_MODEL;
 
 const titleRequestSchema = z.object({
   prompt: z.string().min(1).max(2_000),
@@ -54,8 +54,10 @@ export default async function handler(request: Request): Promise<Response> {
       apiKey: getGatewayApiKey(request, process.env),
     });
 
-    const result = await generateText({
-      model: gateway(selectedModel),
+    const models = process.env.DEANA_LLM_MODEL ? [process.env.DEANA_LLM_MODEL] : TASK_MODELS.titleGeneration;
+    const result = await runTextWithFallback({
+      gateway,
+      models,
       system: [
         "Create a short, specific Deana chat title from the user's first message only.",
         "Use two to six words.",
@@ -69,7 +71,8 @@ export default async function handler(request: Request): Promise<Response> {
       ].join("\n"),
       prompt: parsed.data.prompt,
       maxOutputTokens: 200,
-      providerOptions: buildGatewayProviderOptions(selectedModel),
+      providerOptionsFor: (model) => buildGatewayProviderOptions(model),
+      taskName: "chat-title",
     });
 
     const title = formatChatTitle(result.text);

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,14 +1,15 @@
 import { createGateway } from "@ai-sdk/gateway";
-import { convertToModelMessages, streamText, type UIMessage } from "ai";
+import { convertToModelMessages, type UIMessage } from "ai";
 import { z } from "zod";
 import { getGatewayApiKey, isSameOrigin } from "../src/lib/aiGatewayAuth";
 import {
   buildGatewayProviderOptions,
   CHAT_CONSENT_VERSION,
   CHAT_CONTEXT_VERSION,
-  DEFAULT_DEANA_LLM_MODEL,
   MAX_CHAT_CONTEXT_FINDINGS,
 } from "../src/lib/aiChat";
+import { selectChatModels } from "../src/lib/ai/models";
+import { runStreamWithFallback } from "../src/lib/ai/run-with-fallback";
 
 declare const process: {
   env: Record<string, string | undefined>;
@@ -26,7 +27,6 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 20;
 
 const requestCounts = new Map<string, { count: number; resetAt: number }>();
-const selectedModel = process.env.DEANA_LLM_MODEL ?? DEFAULT_DEANA_LLM_MODEL;
 
 const messagePartSchema = z.object({
   type: z.string(),
@@ -250,8 +250,14 @@ export default async function handler(request: Request): Promise<Response> {
       apiKey: getGatewayApiKey(request, process.env),
     });
 
-    const result = streamText({
-      model: gateway(selectedModel),
+    const lastUserMessage = [...messages].reverse().find((m) => m.role === "user");
+    const selectedModels = process.env.DEANA_LLM_MODEL
+      ? [process.env.DEANA_LLM_MODEL]
+      : selectChatModels(parsed.data.context.findings, lastUserMessage ? textFromMessage(lastUserMessage) : "");
+
+    const { result } = await runStreamWithFallback({
+      gateway,
+      models: selectedModels,
       system: buildSystemPrompt(parsed.data.context),
       messages: await convertToModelMessages(messages),
       tools: {
@@ -265,7 +271,8 @@ export default async function handler(request: Request): Promise<Response> {
         },
       },
       maxOutputTokens: MAX_ASSISTANT_OUTPUT_TOKENS,
-      providerOptions: buildGatewayProviderOptions(selectedModel, true),
+      providerOptionsFor: (model) => buildGatewayProviderOptions(model, true),
+      taskName: "chat",
     });
 
     return result.toUIMessageStreamResponse({

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@vercel/analytics": "^2.0.1",
     "ai": "^6.0.168",
     "fflate": "^0.8.2",
+    "minisearch": "^7.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Route, Routes } from "react-router-dom";
 import { deleteProfile, loadProfileMeta, loadProfileSummaries, saveProfile } from "./lib/storage";
 import { createProfile as buildProfile } from "./lib/profiles";
+import { clearSearchIndex, prewarmSearchIndex } from "./lib/ai/searchIndex";
 import {
   DnaParseProgress,
   EvidenceProgressSnapshot,
@@ -156,6 +157,8 @@ export default function App() {
       packVersion: evidenceSupplement.packVersion,
     });
     await saveProfile(nextProfile);
+    clearSearchIndex(nextProfile.id);
+    void prewarmSearchIndex(nextProfile.id);
     const summary = summaryFromProfile(nextProfile);
     setProfiles((current) => [summary, ...current.filter((candidate) => candidate.id !== summary.id)]);
     void loadProfileSummaries().then(setProfiles).catch(() => {});
@@ -188,6 +191,7 @@ export default function App() {
       report: generateReport(existing.dna, { ...existing.supplements, evidence: runningSupplement }),
     };
     await saveProfile(runningProfile);
+    clearSearchIndex(runningProfile.id);
     setProfiles(await loadProfileSummaries());
 
     const supplement = await enrichWithEvidence(existing.dna);
@@ -197,6 +201,8 @@ export default function App() {
       report: generateReport(existing.dna, { ...runningProfile.supplements, evidence: supplement }),
     };
     await saveProfile(refreshed);
+    clearSearchIndex(refreshed.id);
+    void prewarmSearchIndex(refreshed.id);
     setProfiles(await loadProfileSummaries());
   }
 

--- a/src/components/deana/aiChat.tsx
+++ b/src/components/deana/aiChat.tsx
@@ -16,6 +16,7 @@ import {
   type ChatSearchPlan,
 } from "../../lib/aiChat";
 import { searchReportEntriesForChat } from "../../lib/aiRetrieval";
+import { prewarmSearchIndex } from "../../lib/ai/searchIndex";
 import {
   loadAiConsent,
   loadChatMessages,
@@ -127,6 +128,8 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const latestFindingsRef = useRef<ChatReportContext["findings"]>([]);
   const traceByMessageRef = useRef<Record<string, ChatRetrievalTrace>>({});
   const contextFindingsByMessageRef = useRef<Record<string, ChatContextFinding[]>>({});
+  const entryCacheRef = useRef<Map<string, Awaited<ReturnType<typeof loadReportEntry>>>>(new Map());
+  const contextCacheRef = useRef<{ key: string; context: ChatReportContext } | null>(null);
   const createdAtByMessageRef = useRef<Record<string, string>>({});
   const reasoningByMessageRef = useRef<Record<string, string>>({});
   const pendingTraceRef = useRef<ChatRetrievalTrace | null>(null);
@@ -153,6 +156,12 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const setMessagesRef = useRef<((messages: UIMessage[] | ((messages: UIMessage[]) => UIMessage[])) => void) | null>(null);
   latestPropsRef.current = props;
   activeThreadRef.current = activeThread;
+
+  useEffect(() => {
+    entryCacheRef.current.clear();
+    contextCacheRef.current = null;
+    void prewarmSearchIndex(props.profile.id);
+  }, [props.profile.id]);
 
   useEffect(() => {
     let isMounted = true;
@@ -379,6 +388,28 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       });
   }
 
+  function resolveChatContext(): ChatReportContext {
+    const latest = latestPropsRef.current;
+    const retrievedFindings = latestFindingsRef.current;
+    const key = JSON.stringify({
+      profileId: latest.profile.id,
+      profileCreatedAt: latest.profile.createdAt,
+      currentTab: latest.currentTab,
+      filters: latest.filters,
+      visibleIds: latest.visibleEntries.map((entry) => entry.id),
+      selectedId: latest.selectedEntry?.id ?? null,
+      retrievedIds: retrievedFindings.map((finding) => finding.id),
+    });
+
+    const cached = contextCacheRef.current;
+    if (cached?.key === key) return cached.context;
+
+    const context = buildChatContext({ ...latest, retrievedFindings });
+    contextCacheRef.current = { key, context };
+    return context;
+  }
+
+
   const transport = useMemo(() => new DefaultChatTransport({
     api: "/api/chat",
     prepareSendMessagesRequest: async ({ api, messages, body }) => {
@@ -392,7 +423,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
             accepted: true,
             version: CHAT_CONSENT_VERSION,
           },
-          context: buildChatContext({ ...latestPropsRef.current, retrievedFindings: latestFindingsRef.current }),
+          context: resolveChatContext(),
           messages,
         },
       };
@@ -574,7 +605,11 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     if (!href?.startsWith("deana://entry/")) return;
     const entryId = decodeURIComponent(href.slice("deana://entry/".length));
     setPanel({ mode: "inspector", findingId: entryId, finding: null, isLoading: true, error: null });
-    const finding = await loadReportEntry(latestPropsRef.current.profile.id, entryId);
+    const cached = entryCacheRef.current.get(entryId);
+    const finding = cached === undefined
+      ? await loadReportEntry(latestPropsRef.current.profile.id, entryId)
+      : cached;
+    if (cached === undefined) entryCacheRef.current.set(entryId, finding);
     setPanel({
       mode: "inspector",
       findingId: entryId,

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,0 +1,30 @@
+export const DEANA_MODELS = {
+  cheap: "google/gemma-4-31b-it",
+  default: "google/gemini-3-flash",
+  strongFallback: "openai/gpt-5.4-mini",
+} as const;
+
+export type DeanaModelId = typeof DEANA_MODELS[keyof typeof DEANA_MODELS];
+
+export const TASK_MODELS = {
+  titleGeneration: [DEANA_MODELS.cheap, DEANA_MODELS.default],
+  uploadParsingExplanations: [DEANA_MODELS.cheap, DEANA_MODELS.default],
+  traitSummaries: [DEANA_MODELS.cheap, DEANA_MODELS.default],
+  medicalFindingSummaries: [DEANA_MODELS.default, DEANA_MODELS.strongFallback],
+  drugResponseSummaries: [DEANA_MODELS.default, DEANA_MODELS.strongFallback],
+  jsonExtraction: [DEANA_MODELS.cheap, DEANA_MODELS.default],
+  safetyReview: [DEANA_MODELS.default, DEANA_MODELS.strongFallback],
+} as const satisfies Record<string, readonly DeanaModelId[]>;
+
+const ADVISORY_INTENT_PATTERN = /\b(should i|what should|diagnose|treat|medication|recommend|advice)\b/i;
+
+export function selectChatModels(
+  findings: Array<{ category: string; evidenceTier: string }>,
+  userMessage: string,
+): readonly DeanaModelId[] {
+  if (findings.length === 0) return [DEANA_MODELS.default, DEANA_MODELS.strongFallback];
+  if (findings.some((finding) => finding.category === "medical" || finding.category === "drug")) return [DEANA_MODELS.default, DEANA_MODELS.strongFallback];
+  if (findings.some((finding) => finding.evidenceTier === "high" || finding.evidenceTier === "moderate")) return [DEANA_MODELS.default, DEANA_MODELS.strongFallback];
+  if (ADVISORY_INTENT_PATTERN.test(userMessage)) return [DEANA_MODELS.default, DEANA_MODELS.strongFallback];
+  return [DEANA_MODELS.cheap, DEANA_MODELS.default];
+}

--- a/src/lib/ai/run-with-fallback.ts
+++ b/src/lib/ai/run-with-fallback.ts
@@ -1,0 +1,47 @@
+import { generateText, streamText, type ModelMessage, type ToolSet } from "ai";
+import type { createGateway } from "@ai-sdk/gateway";
+import { buildGatewayProviderOptions } from "../aiChat";
+
+export function isRetryableError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return ["rate limit", "timeout", "overloaded", "temporarily unavailable", "service unavailable", "gateway", "model unavailable"].some((token) => message.includes(token));
+}
+
+interface CommonOptions {
+  gateway: ReturnType<typeof createGateway>;
+  models: readonly string[];
+  providerOptionsFor?: (model: string) => ReturnType<typeof buildGatewayProviderOptions>;
+  system: string;
+  maxOutputTokens: number;
+  taskName: string;
+}
+
+export async function runTextWithFallback({ gateway, models, providerOptionsFor, system, prompt, temperature, maxOutputTokens, taskName }: CommonOptions & { prompt: string; temperature?: number; }): Promise<{ text: string; modelUsed: string; fallbackAttempts: number; }> {
+  let lastError: unknown;
+  for (let i = 0; i < models.length; i += 1) {
+    const model = models[i];
+    try {
+      const result = await generateText({ model: gateway(model), system, prompt, temperature, maxOutputTokens, providerOptions: providerOptionsFor?.(model) });
+      return { text: result.text, modelUsed: model, fallbackAttempts: i };
+    } catch (error) {
+      lastError = error;
+      if (i === models.length - 1 || !isRetryableError(error)) break;
+    }
+  }
+  throw new Error(`${taskName} failed across ${models.length} model(s): ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}
+
+export async function runStreamWithFallback({ gateway, models, providerOptionsFor, system, messages, tools, maxOutputTokens, taskName }: CommonOptions & { messages: ModelMessage[]; tools?: ToolSet; }): Promise<{ result: ReturnType<typeof streamText>; modelUsed: string; }> {
+  let lastError: unknown;
+  for (let i = 0; i < models.length; i += 1) {
+    const model = models[i];
+    try {
+      const result = streamText({ model: gateway(model), system, messages, tools, maxOutputTokens, providerOptions: providerOptionsFor?.(model) });
+      return { result, modelUsed: model };
+    } catch (error) {
+      lastError = error;
+      if (i === models.length - 1 || !isRetryableError(error)) break;
+    }
+  }
+  throw new Error(`${taskName} failed across ${models.length} model(s): ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}

--- a/src/lib/ai/searchIndex.ts
+++ b/src/lib/ai/searchIndex.ts
@@ -1,0 +1,71 @@
+import MiniSearch from "minisearch";
+import { streamReportEntries } from "../storage";
+
+interface LightEntry {
+  id: string;
+  category: string;
+  title: string;
+  genes: string;
+  topics: string;
+  conditions: string;
+  rsids: string;
+  evidenceTier: string;
+}
+
+const indexes = new Map<string, MiniSearch<LightEntry>>();
+const inFlight = new Map<string, Promise<void>>();
+
+function toLightEntry(entry: Awaited<ReturnType<typeof streamReportEntries>> extends AsyncGenerator<infer T> ? T : never): LightEntry {
+  return {
+    id: entry.id,
+    category: entry.category,
+    title: entry.title.slice(0, 120),
+    genes: entry.genes.join(" "),
+    topics: entry.topics.join(" "),
+    conditions: entry.conditions.join(" "),
+    rsids: entry.matchedMarkers.map((marker) => marker.rsid).join(" "),
+    evidenceTier: entry.evidenceTier,
+  };
+}
+
+export async function prewarmSearchIndex(profileId: string): Promise<void> {
+  if (indexes.has(profileId)) return;
+  if (inFlight.has(profileId)) return inFlight.get(profileId);
+
+  const job = (async () => {
+    const miniSearch = new MiniSearch<LightEntry>({
+      idField: "id",
+      fields: ["genes", "conditions", "topics", "title", "rsids", "category", "evidenceTier"],
+      storeFields: ["id"],
+      searchOptions: { fuzzy: 0.2, prefix: true, boost: { genes: 4, conditions: 3, topics: 3, title: 2, rsids: 4 } },
+    });
+
+    for await (const entry of streamReportEntries(profileId)) {
+      miniSearch.add(toLightEntry(entry));
+    }
+    indexes.set(profileId, miniSearch);
+  })().finally(() => inFlight.delete(profileId));
+
+  inFlight.set(profileId, job);
+  return job;
+}
+
+export async function queryCandidateIds(profileId: string, terms: string[], limit = 50): Promise<string[]> {
+  if (terms.length === 0) return [];
+  await prewarmSearchIndex(profileId);
+  const index = indexes.get(profileId);
+  if (!index) return [];
+  const query = terms.join(" ").trim();
+  if (!query) return [];
+  return index.search(query, { fuzzy: 0.2, prefix: true }).slice(0, limit).map((result) => result.id as string);
+}
+
+export function clearSearchIndex(profileId?: string): void {
+  if (profileId) {
+    indexes.delete(profileId);
+    inFlight.delete(profileId);
+    return;
+  }
+  indexes.clear();
+  inFlight.clear();
+}

--- a/src/lib/aiChat.ts
+++ b/src/lib/aiChat.ts
@@ -3,7 +3,6 @@ import type { ExplorerTab, InsightCategory, ProfileMeta, ReportEntry, StoredRepo
 
 export const CHAT_CONTEXT_VERSION = 1;
 export const CHAT_CONSENT_VERSION = 1;
-export const DEFAULT_DEANA_LLM_MODEL = "google/gemini-3-flash";
 export const MAX_CHAT_CONTEXT_FINDINGS = 18;
 export const MAX_CHAT_SEARCH_RESULTS = 8;
 
@@ -59,6 +58,7 @@ export function buildGatewayProviderOptions(model: string, includeThoughts = fal
   const isOpenAiGatewayModel = model.startsWith("openai/");
 
   return {
+    // Gemma routes use only gateway privacy flags; no Gemini/OpenAI provider options.
     ...(isGeminiGatewayModel
       ? {
           google: {

--- a/src/lib/aiRetrieval.test.ts
+++ b/src/lib/aiRetrieval.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildEntrySearchText } from "./explorer";
 import { searchReportEntriesForChat } from "./aiRetrieval";
-import { streamReportEntries } from "./storage";
+import { loadReportEntriesByIds, streamReportEntries } from "./storage";
 import { makeSavedProfile } from "../test/fixtures";
 import type { ChatSearchPlan } from "./aiChat";
 import type { InsightCategory, StoredReportEntry } from "../types";
 
 vi.mock("./storage", () => ({
   streamReportEntries: vi.fn(),
+  loadReportEntriesByIds: vi.fn(),
 }));
 
 function storedEntries(): StoredReportEntry[] {
@@ -26,6 +27,14 @@ function installEntries(entries: StoredReportEntry[]) {
         yield entry;
       }
     }
+  });
+
+  vi.mocked(loadReportEntriesByIds).mockImplementation(async (profileId: string, ids: string[]) => {
+    const results: StoredReportEntry[] = [];
+    for await (const entry of streamReportEntries(profileId)) {
+      if (ids.includes(entry.id)) results.push(entry);
+    }
+    return results;
   });
 }
 

--- a/src/lib/aiRetrieval.ts
+++ b/src/lib/aiRetrieval.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_FILTERS, matchesEntryFilters } from "./explorer";
-import { findingToChatContext, MAX_CHAT_SEARCH_RESULTS, type ChatContextFinding, type ChatSearchPlan } from "./aiChat";
-import { streamReportEntries } from "./storage";
+import { findingToChatContext, type ChatContextFinding, type ChatSearchPlan } from "./aiChat";
+import { queryCandidateIds } from "./ai/searchIndex";
+import { loadReportEntriesByIds, streamReportEntries } from "./storage";
 import type { ChatRetrievalTrace, InsightCategory, StoredReportEntry } from "../types";
 
 const ALL_CATEGORIES: InsightCategory[] = ["medical", "traits", "drug"];
@@ -198,11 +199,18 @@ function fallbackPlan(prompt: string): ChatSearchPlan {
   };
 }
 
+function resolveLimit(plan: ChatSearchPlan): number {
+  if (plan.rsids.length > 0) return 5;
+  if (plan.genes.length > 0) return 10;
+  if (plan.conditions.length + plan.topics.length > 3) return 15;
+  return 12;
+}
+
 export async function searchReportEntriesForChat({
   profileId,
   prompt,
   plan,
-  limit = MAX_CHAT_SEARCH_RESULTS,
+  limit,
 }: {
   profileId: string;
   prompt: string;
@@ -214,15 +222,22 @@ export async function searchReportEntriesForChat({
   const terms = searchTerms(prompt, effectivePlan);
   const ranked: Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }> = [];
   const seen = new Set<string>();
+  const candidateIds = await queryCandidateIds(profileId, terms, 50);
+  const indexedEntries = candidateIds.length > 0 ? await loadReportEntriesByIds(profileId, candidateIds) : [];
 
-  for (const category of categories) {
-    for await (const entry of streamReportEntries(profileId, category)) {
+  for (const entry of indexedEntries) {
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    const { score, matchedFields } = scoreEntry(entry, prompt, effectivePlan, terms);
+    if (matchedFields.length > 0) ranked.push({ entry, score, matchedFields });
+  }
+
+  if (ranked.length === 0) {
+    for await (const entry of streamReportEntries(profileId)) {
       if (seen.has(entry.id)) continue;
       seen.add(entry.id);
       const { score, matchedFields } = scoreEntry(entry, prompt, effectivePlan, terms);
-      if (matchedFields.length > 0) {
-        ranked.push({ entry, score, matchedFields });
-      }
+      if (matchedFields.length > 0) ranked.push({ entry, score, matchedFields });
     }
   }
 
@@ -232,7 +247,7 @@ export async function searchReportEntriesForChat({
     left.entry.title.localeCompare(right.entry.title),
   );
 
-  const selectedRanked = ranked.slice(0, limit);
+  const selectedRanked = ranked.slice(0, limit ?? resolveLimit(effectivePlan));
   const selected = selectedRanked.map(({ entry }) => findingToChatContext(entry));
 
   return {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -592,6 +592,14 @@ export async function loadReportEntry(profileId: string, entryId: string): Promi
   return entry ?? null;
 }
 
+export async function loadReportEntriesByIds(
+  profileId: string,
+  ids: string[],
+): Promise<StoredReportEntry[]> {
+  const entries = await Promise.all(ids.map((id) => loadReportEntry(profileId, id)));
+  return entries.filter((entry): entry is StoredReportEntry => Boolean(entry));
+}
+
 async function loadAllEntriesForCategory(
   profileId: string,
   category: StoredReportEntry["category"],


### PR DESCRIPTION
### Motivation
- Improve reliability and privacy of AI features by adding model fallback and gateway-aware provider options for both chat and title generation.
- Speed up and localize report retrieval for AI-assisted search by adding an in-memory full-text index and prewarm/clear hooks.
- Reduce repeated I/O and context rebuilds in the UI by caching report entry loads and chat context.

### Description
- Introduces model metadata and selection logic in `src/lib/ai/models.ts` and replaces single-model usage with per-task model lists and selection heuristics used by chat and title APIs. 
- Adds fallback runners in `src/lib/ai/run-with-fallback.ts` to try multiple models with retryable-error handling, and switches `api/chat.ts` and `api/chat-title.ts` to use `runStreamWithFallback` / `runTextWithFallback` with `providerOptionsFor` callbacks.
- Implements a lightweight local search index using `minisearch` in `src/lib/ai/searchIndex.ts` with `prewarmSearchIndex`, `queryCandidateIds`, and `clearSearchIndex`, and wires it into retrieval logic in `src/lib/aiRetrieval.ts` to first query candidate IDs before falling back to streaming all report entries.
- Adds `loadReportEntriesByIds` to `src/lib/storage.ts` and updates tests and mocks accordingly; updates `package.json` to include `minisearch`.
- Adds UI improvements: prewarming/clearing the search index in `src/App.tsx`, caching of loaded report entries and chat context in `src/components/deana/aiChat.tsx`, and minor changes in `src/lib/aiChat.ts` to provider option comments and removed hardcoded default model constant.

### Testing
- Ran the unit test suite with `vitest run` and the updated tests including `src/lib/aiRetrieval.test.ts` passed.
- The `aiRetrieval` tests were updated to mock `loadReportEntriesByIds` and passed under the new indexed retrieval flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1548fa7d883288be6fdc220adf7a8)