### PR TITLE
Prefer cheap model for greetings; enrich search index and improve retrieval ranking

### DIFF
--- a/src/lib/ai/models.test.ts
+++ b/src/lib/ai/models.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { DEANA_MODELS, selectChatModels } from "./models";
+
+describe("selectChatModels", () => {
+  it("prefers Gemma for simple greetings", () => {
+    expect(selectChatModels([{ category: "medical", evidenceTier: "high" }], "hello")).toEqual([
+      DEANA_MODELS.cheap,
+      DEANA_MODELS.default,
+    ]);
+  });
+
+  it("keeps stronger routing for advisory medical prompts", () => {
+    expect(selectChatModels([{ category: "medical", evidenceTier: "high" }], "Should I take medication?")).toEqual([
+      DEANA_MODELS.default,
+      DEANA_MODELS.strongFallback,
+    ]);
+  });
+});

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -17,11 +17,13 @@ export const TASK_MODELS = {
 } as const satisfies Record<string, readonly DeanaModelId[]>;
 
 const ADVISORY_INTENT_PATTERN = /\b(should i|what should|diagnose|treat|medication|recommend|advice)\b/i;
+const GREETING_PATTERN = /^(hi|hello|hey|yo|sup|good (morning|afternoon|evening))(?:[!.?,\s]+|$)/i;
 
 export function selectChatModels(
   findings: Array<{ category: string; evidenceTier: string }>,
   userMessage: string,
 ): readonly DeanaModelId[] {
+  if (GREETING_PATTERN.test(userMessage.trim())) return [DEANA_MODELS.cheap, DEANA_MODELS.default];
   if (findings.length === 0) return [DEANA_MODELS.default, DEANA_MODELS.strongFallback];
   if (findings.some((finding) => finding.category === "medical" || finding.category === "drug")) return [DEANA_MODELS.default, DEANA_MODELS.strongFallback];
   if (findings.some((finding) => finding.evidenceTier === "high" || finding.evidenceTier === "moderate")) return [DEANA_MODELS.default, DEANA_MODELS.strongFallback];

--- a/src/lib/ai/searchIndex.ts
+++ b/src/lib/ai/searchIndex.ts
@@ -10,12 +10,22 @@ interface LightEntry {
   conditions: string;
   rsids: string;
   evidenceTier: string;
+  summary: string;
+  detail: string;
+  sourceNotes: string;
+  markers: string;
+  searchText: string;
 }
 
 const indexes = new Map<string, MiniSearch<LightEntry>>();
 const inFlight = new Map<string, Promise<void>>();
 
 function toLightEntry(entry: Awaited<ReturnType<typeof streamReportEntries>> extends AsyncGenerator<infer T> ? T : never): LightEntry {
+  const markers = entry.matchedMarkers
+    .flatMap((marker) => [marker.rsid, marker.gene ?? "", marker.genotype ?? "", marker.matchedAllele ?? ""])
+    .filter(Boolean)
+    .join(" ");
+
   return {
     id: entry.id,
     category: entry.category,
@@ -25,6 +35,11 @@ function toLightEntry(entry: Awaited<ReturnType<typeof streamReportEntries>> ext
     conditions: entry.conditions.join(" "),
     rsids: entry.matchedMarkers.map((marker) => marker.rsid).join(" "),
     evidenceTier: entry.evidenceTier,
+    summary: entry.summary.slice(0, 320),
+    detail: entry.detail.slice(0, 640),
+    sourceNotes: entry.sourceNotes.join(" ").slice(0, 320),
+    markers,
+    searchText: (entry.searchText || "").slice(0, 960),
   };
 }
 
@@ -35,9 +50,24 @@ export async function prewarmSearchIndex(profileId: string): Promise<void> {
   const job = (async () => {
     const miniSearch = new MiniSearch<LightEntry>({
       idField: "id",
-      fields: ["genes", "conditions", "topics", "title", "rsids", "category", "evidenceTier"],
+      fields: ["genes", "conditions", "topics", "title", "rsids", "markers", "summary", "detail", "sourceNotes", "searchText", "category", "evidenceTier"],
       storeFields: ["id"],
-      searchOptions: { fuzzy: 0.2, prefix: true, boost: { genes: 4, conditions: 3, topics: 3, title: 2, rsids: 4 } },
+      searchOptions: {
+        fuzzy: 0.2,
+        prefix: true,
+        boost: {
+          rsids: 8,
+          markers: 7,
+          genes: 6,
+          conditions: 5,
+          title: 4,
+          topics: 3,
+          summary: 3,
+          detail: 2,
+          sourceNotes: 2,
+          searchText: 1,
+        },
+      },
     });
 
     for await (const entry of streamReportEntries(profileId)) {

--- a/src/lib/aiRetrieval.ts
+++ b/src/lib/aiRetrieval.ts
@@ -222,22 +222,27 @@ export async function searchReportEntriesForChat({
   const terms = searchTerms(prompt, effectivePlan);
   const ranked: Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }> = [];
   const seen = new Set<string>();
-  const candidateIds = await queryCandidateIds(profileId, terms, 50);
-  const indexedEntries = candidateIds.length > 0 ? await loadReportEntriesByIds(profileId, candidateIds) : [];
+  const indexCandidateLimit = Math.max(60, (limit ?? resolveLimit(effectivePlan)) * 8);
+  const candidateIds = await queryCandidateIds(profileId, terms, indexCandidateLimit);
+  const indexedEntries = candidateIds.length > 0 ? await loadReportEntriesByIds(profileId, candidateIds.slice(0, indexCandidateLimit)) : [];
+
+  const rankEntry = (entry: StoredReportEntry) => {
+    if (seen.has(entry.id)) return;
+    seen.add(entry.id);
+    const { score, matchedFields } = scoreEntry(entry, prompt, effectivePlan, terms);
+    if (matchedFields.length > 0) ranked.push({ entry, score, matchedFields });
+  };
 
   if (indexedEntries.length > 0) {
     for (const entry of indexedEntries) {
-      if (seen.has(entry.id)) continue;
-      seen.add(entry.id);
-      const { score, matchedFields } = scoreEntry(entry, prompt, effectivePlan, terms);
-      if (matchedFields.length > 0) ranked.push({ entry, score, matchedFields });
+      rankEntry(entry);
     }
-  } else {
+  }
+
+  const targetMatches = Math.max(18, (limit ?? resolveLimit(effectivePlan)) * 3);
+  if (indexedEntries.length === 0 || ranked.length < targetMatches) {
     for await (const entry of streamReportEntries(profileId)) {
-      if (seen.has(entry.id)) continue;
-      seen.add(entry.id);
-      const { score, matchedFields } = scoreEntry(entry, prompt, effectivePlan, terms);
-      if (matchedFields.length > 0) ranked.push({ entry, score, matchedFields });
+      rankEntry(entry);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Prefer a cheaper model for obvious greetings to save cost and route simple chats faster. 
- Improve search relevance by indexing more report fields and boosting marker/rsid matches. 
- Make retrieval more robust by fetching a larger candidate set and falling back to streaming when the index doesn't return enough matches.

### Description
- Added a `GREETING_PATTERN` and a greeting shortcut in `selectChatModels` to return `[DEANA_MODELS.cheap, DEANA_MODELS.default]` for simple greetings and added unit tests in `src/lib/ai/models.test.ts` for this behavior. 
- Extended `LightEntry` in `src/lib/ai/searchIndex.ts` with `summary`, `detail`, `sourceNotes`, `markers`, and `searchText`, and populated `markers` from `matchedMarkers` in `toLightEntry`. 
- Updated `prewarmSearchIndex` to index the new fields and adjusted `MiniSearch` `fields` and `searchOptions.boost` to prioritize `rsids`, `markers`, and `genes` while including `summary`/`detail`/`sourceNotes` in ranking. 
- Reworked retrieval logic in `src/lib/aiRetrieval.ts` to compute `indexCandidateLimit`, request more candidate IDs from the index, introduce a `rankEntry` helper to deduplicate and score entries, and add a `targetMatches` threshold to trigger streaming over all entries when the index results are insufficient.

### Testing
- Ran unit tests with `vitest`, including the new `selectChatModels` tests in `src/lib/ai/models.test.ts`, and they passed. 
- Verified TypeScript compilation with `tsc --noEmit`, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ccf320bc8328b1c5e48d98f7185a)