### PR TITLE
Display routed AI model in chat UI for non-production deployments

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -255,7 +255,7 @@ export default async function handler(request: Request): Promise<Response> {
       ? [process.env.DEANA_LLM_MODEL]
       : selectChatModels(parsed.data.context.findings, lastUserMessage ? textFromMessage(lastUserMessage) : "");
 
-    const { result } = await runStreamWithFallback({
+    const { result, modelUsed } = await runStreamWithFallback({
       gateway,
       models: selectedModels,
       system: buildSystemPrompt(parsed.data.context),
@@ -275,10 +275,13 @@ export default async function handler(request: Request): Promise<Response> {
       taskName: "chat",
     });
 
+    const exposeModelName = process.env.VERCEL_ENV !== "production";
+
     return result.toUIMessageStreamResponse({
       headers: {
         "Cache-Control": "no-store",
       },
+      messageMetadata: () => (exposeModelName ? { model: modelUsed } : undefined),
       sendReasoning: true,
       onError: () => "AI chat is unavailable with the current Gateway privacy settings.",
     });

--- a/src/components/deana/aiChat.tsx
+++ b/src/components/deana/aiChat.tsx
@@ -82,6 +82,13 @@ function messageReasoning(message: UIMessage): string | null {
   return text || null;
 }
 
+function messageModel(message: UIMessage): string | null {
+  const metadata = message.metadata;
+  if (!metadata || typeof metadata !== "object") return null;
+  const candidate = "model" in metadata ? metadata.model : null;
+  return typeof candidate === "string" && candidate.trim() ? candidate : null;
+}
+
 function toUiMessages(messages: StoredChatMessage[]): UIMessage[] {
   return messages.map((message) => ({
     id: message.id,
@@ -691,6 +698,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
                   key={message.id}
                   role={message.role}
                   content={messageText(message)}
+                  modelName={messageModel(message)}
                   trace={traceByMessageRef.current[message.id]}
                   reasoningSummary={messageReasoning(message) ?? reasoningByMessageRef.current[message.id] ?? null}
                   components={markdownComponents}
@@ -1064,6 +1072,7 @@ const rehypePlugins = [[rehypeSanitize, markdownSchema]] as Parameters<typeof Re
 const ChatMessage = memo(function ChatMessage({
   role,
   content,
+  modelName,
   trace,
   reasoningSummary,
   components,
@@ -1072,6 +1081,7 @@ const ChatMessage = memo(function ChatMessage({
 }: {
   role: UIMessage["role"];
   content: string;
+  modelName: string | null;
   trace?: ChatRetrievalTrace;
   reasoningSummary: string | null;
   components: Components;
@@ -1084,6 +1094,7 @@ const ChatMessage = memo(function ChatMessage({
 
   return (
     <article className={`dn-ai-message dn-ai-message--${role}`}>
+      {role === "assistant" && modelName ? <p className="dn-ai-model-name">Model: {modelName}</p> : null}
       {hasReasoning && role === "assistant" ? <ModelReasoning reasoning={reasoningSummary ?? ""} /> : null}
       {content ? (
         <ReactMarkdown

--- a/src/styles.css
+++ b/src/styles.css
@@ -874,6 +874,13 @@ a { color: inherit; }
 .dn-ai-message p:last-child,
 .dn-ai-message ul:last-child,
 .dn-ai-message ol:last-child { margin-bottom: 0; }
+.dn-ai-model-name {
+  margin: 0;
+  color: var(--dn-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
 .dn-ai-message code {
   padding: 2px 5px;
   border-radius: 5px;


### PR DESCRIPTION
### Motivation
- Make it visible which routed model responded to an AI chat prompt in non-production environments to aid debugging and QA without exposing model routing in production.

### Description
- Expose the selected fallback model id from `runStreamWithFallback` in the chat Edge handler and attach it as assistant message metadata only when `process.env.VERCEL_ENV !== "production"` via `messageMetadata` on `toUIMessageStreamResponse`.
- Add a `messageModel` helper in the client chat UI to read `message.metadata.model` from incoming `UIMessage` objects.
- Render the model id above assistant replies inside the `ChatMessage` component as `Model: <name>` and wire the helper into the message mapping in `ExplorerAiChat`.
- Add subtle styling for the model label in `src/styles.css` so the label appears as muted metadata above assistant messages.

### Testing
- Ran `bun run test` which exercised the Vitest suite and produced passing tests for many modules but the run failed due to a pre-existing unresolved dependency error: `minisearch` could not be resolved from `src/lib/ai/searchIndex.ts` (test run status: failed).
- Ran `bun run build` which also failed for the same existing `minisearch` module/type errors (build status: failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d88c1b2083288a9a9e40ee6ae06b)