### PR TITLE
Add in-app AI search debug timeline

### DIFF
--- a/src/components/deana/aiChat.tsx
+++ b/src/components/deana/aiChat.tsx
@@ -59,6 +59,12 @@ type ChatPanel =
   | { mode: "findings" }
   | { mode: "inspector"; findingId: string; finding: StoredReportEntry | null; isLoading: boolean; error: string | null };
 
+interface SearchDebugEvent {
+  at: string;
+  label: string;
+  detail: string;
+}
+
 const entryLinkPattern = /deana:\/\/entry\/[A-Za-z0-9._~!$&'()*+,;=:@%-]+/g;
 
 function makeId(prefix: string): string {
@@ -147,6 +153,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const [initialMessages, setInitialMessages] = useState<UIMessage[]>([]);
   const [input, setInput] = useState("");
   const [searchStatus, setSearchStatus] = useState<SearchStatus>({ status: "idle" });
+  const [searchDebugEvents, setSearchDebugEvents] = useState<SearchDebugEvent[]>([]);
   const [isThreadListOpen, setIsThreadListOpen] = useState(true);
   const [isThreadPanelCollapsed, setIsThreadPanelCollapsed] = useState(false);
   const [modal, setModal] = useState<"chatPrivacy" | null>(null);
@@ -160,6 +167,11 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const setMessagesRef = useRef<((messages: UIMessage[] | ((messages: UIMessage[]) => UIMessage[])) => void) | null>(null);
   latestPropsRef.current = props;
   activeThreadRef.current = activeThread;
+
+  const pushSearchDebug = useCallback((label: string, detail: string) => {
+    const next: SearchDebugEvent = { at: new Date().toISOString(), label, detail };
+    setSearchDebugEvents((current) => [...current.slice(-14), next]);
+  }, []);
 
   useEffect(() => {
     let isMounted = true;
@@ -390,6 +402,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     api: "/api/chat",
     prepareSendMessagesRequest: async ({ api, messages, body }) => {
       setSearchStatus((current) => current.status === "searching" || current.status === "ready" ? current : { status: "checking" });
+      pushSearchDebug("send", `Submitting ${messages.length} messages with ${latestFindingsRef.current.length} retrieved findings in context.`);
 
       return {
         api,
@@ -424,9 +437,11 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       if (toolCall.dynamic || toolCall.toolName !== "searchReportFindings") return;
 
       setSearchStatus({ status: "searching" });
+      pushSearchDebug("tool-call", "searchReportFindings tool call received from model.");
 
       try {
         const plan = toolCall.input as ChatSearchPlan;
+        pushSearchDebug("planner", `Query: ${plan.query || "(empty)"}; terms: genes=${plan.genes.length}, rsids=${plan.rsids.length}, conditions=${plan.conditions.length}.`);
         const retrieval = await searchReportEntriesForChat({
           profileId: latestPropsRef.current.profile.id,
           prompt: plan.query,
@@ -439,6 +454,8 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
         pendingTraceRef.current = retrieval.trace;
         pendingFindingsRef.current = latestFindingsRef.current;
         setSearchStatus({ status: "ready", trace: retrieval.trace });
+        pushSearchDebug("results", `Found ${retrieval.resultCount} matching findings. Top searched terms: ${retrieval.trace.searchedTerms.slice(0, 8).join(", ") || "none"}.`);
+        pushSearchDebug("tool-output", "Returning local findings to model.");
         void addToolOutput({
           tool: "searchReportFindings",
           toolCallId: toolCall.toolCallId,
@@ -451,6 +468,8 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       } catch (error) {
         const message = error instanceof Error ? error.message : "AI report search is unavailable right now.";
         setSearchStatus({ status: "error", message });
+        pushSearchDebug("error", message);
+        pushSearchDebug("tool-output", "Returning local findings to model.");
         void addToolOutput({
           tool: "searchReportFindings",
           toolCallId: toolCall.toolCallId,
@@ -707,6 +726,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
                 />
               ))}
               {isBusy ? <GeneratingStatus status={searchStatus} /> : null}
+              <SearchDebugPanel status={searchStatus} events={searchDebugEvents} />
               {error ? (
                 <div className="dn-ai-error" role="alert">
                   <Icon name="alert" />
@@ -1063,6 +1083,29 @@ function ChatSidePanel({
         />
       )}
     </aside>
+  );
+}
+
+
+function SearchDebugPanel({ status, events }: { status: SearchStatus; events: SearchDebugEvent[] }) {
+  return (
+    <details className="dn-ai-trace">
+      <summary><Icon name="search" /> Search debug ({events.length})</summary>
+      <div className="dn-ai-trace__body">
+        <p>Status: <strong>{status.status}</strong></p>
+        {status.status === "error" ? <p className="dn-error-text">{status.message}</p> : null}
+        {events.length === 0 ? <p>No search events yet.</p> : (
+          <ol>
+            {events.slice().reverse().map((event) => (
+              <li key={`${event.at}-${event.label}`}>
+                <strong>{event.label}</strong> · {new Date(event.at).toLocaleTimeString()}<br />
+                <span>{event.detail}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </details>
   );
 }
 


### PR DESCRIPTION
### Motivation
- After migrating retrieval to Orama, failures in the chat `searchReportFindings` tool are difficult to diagnose on mobile where the browser console is unavailable.
- Surface a concise, on-device timeline of the chat search lifecycle so maintainers and QA can inspect send, planner, retrieval, and tool-output events without remote logging.
- Keep privacy and data safety: the debug timeline is local UI state only and does not add network calls or expose raw DNA, full marker lists, profile names, or other sensitive payloads.

### Description
- Add a `SearchDebugEvent` type and `searchDebugEvents` state to `ExplorerAiChat` and provide a `pushSearchDebug` helper to append timestamped events.
- Instrument the chat request flow (`prepareSendMessagesRequest`) and tool-call handling (`onToolCall`) to log `send`, `tool-call`, `planner`, `results`, `tool-output`, and `error` events with compact operational metadata.
- Render a collapsible `SearchDebugPanel` inside the chat message area that displays the current `searchStatus` and the most recent debug events for mobile-friendly inspection.
- Change is UI-only and local-state-only; no new network endpoints or changes to chat consent, context-shaping, or data sent to the AI Gateway were introduced.

### Testing
- Ran unit tests: `bun run test src/lib/aiRetrieval.test.ts src/components/deana/aiChat.tsx` which passed (Vitest reports tests OK).
- Built the production bundle with `bun run build` which completed successfully.
- No automated failures were observed after the change; the added UI component is exercised implicitly by the TypeScript build and test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36902416883289e4cd9a99fdbe7c4)