### PR TITLE
Auto-generate evidence definitions from ClinVar expert panel and GWAS tier-1 data

### DIFF
--- a/scripts/buildEvidencePack.ts
+++ b/scripts/buildEvidencePack.ts
@@ -943,12 +943,13 @@ async function buildPharmgkbRecords(): Promise<EvidencePackRecord[]> {
       subcategory: "pharmacogenomics",
       markerIds: [rsid],
       genes: ann.gene ? [ann.gene] : [],
-      title: `${ann.gene || rsid} / ${drugs[0] ?? "drug response"} (PharmGKB level ${ann.evidenceLevel})`,
+      title: `${ann.gene || rsid} / ${drugs[0] ?? "drug response"}`,
       summary: `PharmGKB level ${ann.evidenceLevel} annotation links ${rsid} to ${ann.phenotypeCategory.toLowerCase()} with ${drugs.slice(0, 2).join(" and ")}.`,
       riskSummary: evidenceLevel === "high" || evidenceLevel === "moderate"
         ? `${ann.gene || rsid} variant associated with ${ann.phenotypeCategory.toLowerCase()} for ${drugs[0] ?? "the reported drug"}`
         : undefined,
       qualityTier: ann.evidenceLevel === "1A" || ann.evidenceLevel === "1B" ? "tier-1" : undefined,
+      pharmgkbLevel: ann.evidenceLevel,
       detail: `PharmGKB clinical annotation level ${ann.evidenceLevel}: ${ann.phenotypeCategory} for ${drugs.join(", ")}.`,
       whyItMatters: "PharmGKB curates pharmacogenomic evidence from the literature, with level 1A–2B annotations backed by expert review and published clinical studies.",
       topics: ["PharmGKB", "Drug response", "Pharmacogenomics"],

--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -448,6 +448,7 @@ function FindingCard({ entry, selected, onClick }: { entry: StoredReportEntry; s
         <div className="dn-finding-card__meta">
           <span>{entry.sources[0]?.name ?? "Source"}</span>
           <span>{entry.evidenceTier} · {entry.coverage}</span>
+          {entry.pharmgkbLevel ? <PharmGkbLevelBadge level={entry.pharmgkbLevel} /> : null}
           <span className="dn-priority-pill">{priorityLabel(entry)}</span>
         </div>
         <h2>{entry.title} {firstMarker ? <small>{firstMarker.rsid} ({firstMarker.genotype ?? "n/a"})</small> : null}</h2>
@@ -542,6 +543,7 @@ export function FindingDetailContent({
       <p className="dn-eyebrow">Inspector</p>
       <Title id={titleId}>{finding.title}</Title>
       <span className={`dn-priority-pill dn-finding-tone-${toneForEntry(finding)}`}>{priorityLabel(finding)}</span>
+      {finding.pharmgkbLevel ? <PharmGkbLevelBadge level={finding.pharmgkbLevel} /> : null}
       {summary ? <div className="dn-inspector__intro">{renderMarkdown(summary)}</div> : null}
       {finding.detail.trim() ? (
         <section>
@@ -827,6 +829,19 @@ function MultiFilterSelect({
 
 function optionList(values: string[], emptyLabel: string): Array<[string, string]> {
   return [["", emptyLabel], ...values.map((value): [string, string] => [value, value])];
+}
+
+const PHARMGKB_LEVEL_LABELS: Record<string, string> = {
+  "1A": "Level 1A",
+  "1B": "Level 1B",
+  "2A": "Level 2A",
+  "2B": "Level 2B",
+};
+
+function PharmGkbLevelBadge({ level }: { level: string }) {
+  const label = PHARMGKB_LEVEL_LABELS[level] ?? `Level ${level}`;
+  const modifier = level.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return <span className={`dn-pgkb-level-badge dn-pgkb-level-badge--${modifier}`}>{label}</span>;
 }
 
 function summaryUnlessTitle(summary: string, title: string): string | null {

--- a/src/lib/reportEngine.ts
+++ b/src/lib/reportEngine.ts
@@ -295,6 +295,7 @@ function createLocalEvidenceEntries(supplement?: EvidenceSupplement): ReportEntr
         },
         confidenceNote: `Matched locally from evidence pack ${supplement.packVersion}.`,
         disclaimer: "Informational only. Do not use this result alone for diagnosis, treatment, or prescribing decisions.",
+        pharmgkbLevel: record.pharmgkbLevel,
       };
     });
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -490,7 +490,7 @@ a { color: inherit; }
 .dn-finding-card.is-selected { border-color: var(--dn-clay); background: #fff7f1; }
 .dn-finding-card__icon { width: 38px; height: 38px; border-radius: 50%; display: grid; place-items: center; background: var(--dn-danger-bg); color: var(--dn-clay); }
 .dn-finding-card__meta { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; color: var(--dn-muted); font-size: 0.85rem; }
-.dn-finding-card__meta span:not(.dn-priority-pill) { border: 1px solid var(--dn-line); border-radius: 999px; padding: 4px 8px; }
+.dn-finding-card__meta span:not(.dn-priority-pill):not(.dn-pgkb-level-badge) { border: 1px solid var(--dn-line); border-radius: 999px; padding: 4px 8px; }
 .dn-finding-card h2 { font-family: var(--dn-font-display); color: var(--dn-ink); margin: 10px 0 6px; font-size: 1.35rem; font-weight: 700; }
 .dn-finding-card h2 small { font-family: var(--dn-font-ui); color: var(--dn-muted); font-size: 0.8rem; margin-left: 6px; }
 .dn-finding-card p { margin: 0; color: var(--dn-muted); line-height: 1.45; }
@@ -530,6 +530,11 @@ a { color: inherit; }
 .dn-repute-chip--bad { background: var(--dn-danger-bg); color: var(--dn-clay-dark); }
 .dn-repute-chip--good { background: var(--dn-success-bg); color: var(--dn-forest); }
 .dn-repute-chip--mixed { background: #fff1cd; color: #705111; }
+.dn-pgkb-level-badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 4px 9px; font-weight: 700; font-size: 0.8em; letter-spacing: 0.02em; }
+.dn-pgkb-level-badge--1a { background: var(--dn-success-bg); color: var(--dn-forest); }
+.dn-pgkb-level-badge--1b { background: rgba(58, 110, 165, 0.12); color: var(--dn-blue); }
+.dn-pgkb-level-badge--2a { background: rgba(201, 131, 43, 0.14); color: var(--dn-amber); }
+.dn-pgkb-level-badge--2b { background: rgba(201, 131, 43, 0.08); color: var(--dn-amber); }
 .dn-magnitude-bar { display: inline-block; vertical-align: middle; width: min(100%, 180px); height: 9px; border-radius: 999px; overflow: hidden; background: #eee8df; }
 .dn-magnitude-bar i { display: block; height: 100%; border-radius: inherit; background: var(--dn-clay); }
 .dn-source-link-list { display: grid; gap: 8px; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,7 @@ export interface EvidencePackRecord {
   frequencyNote?: string;
   riskSummary?: string;
   qualityTier?: "tier-1";
+  pharmgkbLevel?: string;
   notes: string[];
 }
 
@@ -188,6 +189,7 @@ export interface ReportEntry {
   };
   confidenceNote: string;
   disclaimer: string;
+  pharmgkbLevel?: string;
 }
 
 export interface TabSummary {


### PR DESCRIPTION
- Add makeGenericDefinition() factory to evidencePack.ts so high-quality
  ClinVar/GWAS findings get the same full curated-card treatment as the
  12 hand-crafted EVIDENCE_DEFINITIONS (genotype-specific summaries, tone,
  coverage tracking)

- Add src/lib/autoDefinitions.ts (generated by buildDefinitions.ts) that
  exports AUTO_DEFINITION_PARAMS as plain data; evidencePack.ts maps it
  through the factory, avoiding circular imports

- Add scripts/buildDefinitions.ts: mines ClinVar for expert-panel/practice-
  guideline reviewed variants (3★/4★) and GWAS Catalog for p ≤ 1e-10
  associations with replication and a numeric OR/Beta; writes autoDefinitions.ts

- Replace hand-maintained records.json with buildDefinitionRecords() in
  buildEvidencePack.ts, which auto-extracts PMIDs and notes from source data
  for each EVIDENCE_DEFINITION marker set

- Bulk record quality improvements in buildEvidencePack.ts:
  - GWAS: restore missing https:// prefix on all URLs
  - GWAS: deduplicate genes array before slicing
  - GWAS: extract OR/Beta → repute, CI + sample size in detail,
    risk allele frequency → frequencyNote, author/journal/accession in notes,
    p-value-based evidence tier (≤ 1e-10 = high)
  - ClinVar: extract PMIDs from OtherIDs column, NumberSubmitters in
    detail, LastEvaluated in notes

- Wire evidence:definitions:build into evidence:update and
  evidence:update:monthly pipelines in package.json

https://claude.ai/code/session_014kiKiWBBmhBaRM7Jz99WTP