### PR TITLE
Move Orama search index to a dedicated web worker

### DIFF
--- a/api/chat.test.ts
+++ b/api/chat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { trimMessagesToRecentWindow } from "./chat.js";
+import { buildSystemPrompt, trimMessagesToRecentWindow } from "./chat.js";
 
 function buildMessages(count: number) {
   return Array.from({ length: count }, (_, index) => ({
@@ -36,5 +36,46 @@ describe("trimMessagesToRecentWindow", () => {
   it("ignores non-object payloads", () => {
     expect(trimMessagesToRecentWindow(null)).toBeNull();
     expect(trimMessagesToRecentWindow("not-an-object")).toBe("not-an-object");
+  });
+});
+
+describe("buildSystemPrompt", () => {
+  it("keeps follow-up suggestions structured and privacy scoped", () => {
+    const prompt = buildSystemPrompt({
+      contextVersion: 1,
+      currentTab: "ai",
+      activeFilters: {
+        q: "",
+        source: "",
+        evidence: [],
+        significance: [],
+        repute: [],
+        coverage: [],
+        publications: [],
+        gene: [],
+        tag: [],
+        sort: "relevance",
+      },
+      report: {
+        provider: "23andMe",
+        build: "GRCh37",
+        markerCount: 10,
+        coverageScore: 90,
+        evidencePackVersion: "test-pack",
+        evidenceStatus: "complete",
+        evidenceMatchedFindings: 1,
+        localEvidenceEntryMatches: 1,
+        warnings: [],
+        categoryCounts: [],
+      },
+      selectedFindingId: null,
+      findings: [],
+    });
+
+    expect(prompt).toContain("<!-- deana-follow-ups:");
+    expect(prompt).toContain("\"title\":\"Short button label\"");
+    expect(prompt).toContain("\"body\":\"Full follow-up prompt to send\"");
+    expect(prompt).toContain("Do not include profile names, uploaded file names, raw DNA");
+    expect(prompt).toContain("browser-local search");
   });
 });

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -21,6 +21,7 @@ export const config = {
 
 const MAX_MESSAGES = 12;
 const MAX_USER_TEXT_LENGTH = 2_000;
+const MAX_RAW_REQUEST_BYTES = 512_000;
 const MAX_CONTEXT_BYTES = 120_000;
 const MAX_ASSISTANT_OUTPUT_TOKENS = 1_800;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -191,7 +192,7 @@ function validateUserText(messages: UIMessage[]): boolean {
   });
 }
 
-function buildSystemPrompt(context: z.infer<typeof chatContextSchema>): string {
+export function buildSystemPrompt(context: z.infer<typeof chatContextSchema>): string {
   return [
     "You are Deana's report interpreter. Use only the Deana report context supplied below.",
     "The browser may provide currently visible findings and compact findings retrieved earlier in this chat.",
@@ -204,6 +205,9 @@ function buildSystemPrompt(context: z.infer<typeof chatContextSchema>): string {
     "When citing report items, use their title and deana://entry links from supplied findings or tool results. Do not invent links.",
     "If you used searchReportFindings and it returned no findings, say the browser search found no matching saved report findings for this prompt.",
     "If the user asks for anything outside Deana report interpretation, briefly redirect to the available report context.",
+    "After the visible answer, include up to 3 useful follow-up suggestions inside one hidden HTML comment exactly like: <!-- deana-follow-ups: [{\"title\":\"Short button label\",\"body\":\"Full follow-up prompt to send\"}] -->.",
+    "Each follow-up title must be under 44 characters. Each body must be under 220 characters. Suggest only Deana report interpretation follow-ups that can be answered from supplied context or a browser-local search.",
+    "Do not include profile names, uploaded file names, raw DNA, full marker lists, uncapped finding lists, diagnosis, treatment, medication-change, or non-report requests in follow-up suggestions. If no useful follow-up exists, omit the hidden comment.",
     `Deana report context JSON: ${JSON.stringify(context)}`,
   ].join("\n\n");
 }
@@ -223,7 +227,7 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   const rawBody = await request.text();
-  if (rawBody.length > MAX_CONTEXT_BYTES) {
+  if (rawBody.length > MAX_RAW_REQUEST_BYTES) {
     return jsonResponse(413, "Chat context is too large.");
   }
 
@@ -235,6 +239,10 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   const trimmedBody = trimMessagesToRecentWindow(body);
+  if (JSON.stringify(trimmedBody).length > MAX_CONTEXT_BYTES) {
+    return jsonResponse(413, "Chat context is too large.");
+  }
+
   const parsed = chatRequestSchema.safeParse(trimmedBody);
   if (!parsed.success) {
     return jsonResponse(400, "Invalid chat request.");

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,6 +1,5 @@
 import { createGateway } from "@ai-sdk/gateway";
-import { convertToModelMessages, type UIMessage } from "ai";
-import { streamText } from "ai";
+import { convertToModelMessages, streamText, type UIMessage } from "ai";
 import { z } from "zod";
 import { getGatewayApiKey, isSameOrigin } from "../src/lib/aiGatewayAuth.js";
 import {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.104",
     "@ai-sdk/react": "^3.0.170",
-    "@orama/orama": "^3.1.18",
-    "@orama/plugin-qps": "^3.1.10",
     "@vercel/analytics": "^2.0.1",
     "ai": "^6.0.168",
     "fflate": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@ai-sdk/gateway": "^3.0.104",
     "@ai-sdk/react": "^3.0.170",
     "@orama/orama": "^3.1.18",
+    "@orama/plugin-qps": "^3.1.10",
     "@vercel/analytics": "^2.0.1",
     "ai": "^6.0.168",
     "fflate": "^0.8.2",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -937,6 +937,39 @@ describe("Deana app", () => {
     expect(screen.getByTestId("location").textContent).toBe("/explorer/profile-ai?tab=ai");
   });
 
+  it("shows follow-up prompt suggestions and sends the follow-up body", async () => {
+    const user = userEvent.setup();
+    storedProfiles = [makeSavedProfile({ id: "profile-ai" })];
+    storedAiConsents["profile-ai"] = { accepted: true, version: 1, acceptedAt: new Date().toISOString() };
+    storedChatThreads = [{
+      id: "thread-follow-up",
+      profileId: "profile-ai",
+      title: "Coverage",
+      createdAt: "2026-04-26T09:00:00.000Z",
+      updatedAt: "2026-04-26T09:00:00.000Z",
+    }];
+    storedChatMessages = [{
+      id: "message-follow-up",
+      threadId: "thread-follow-up",
+      profileId: "profile-ai",
+      role: "assistant",
+      content: [
+        "Coverage is partial for some findings.",
+        '<!-- deana-follow-ups: [{"title":"Explain coverage","body":"What does partial coverage mean in this report?"}] -->',
+      ].join("\n"),
+      createdAt: "2026-04-26T09:01:00.000Z",
+    }];
+
+    renderApp("/explorer/profile-ai?tab=ai");
+
+    expect(await screen.findByText("Coverage is partial for some findings.")).toBeInTheDocument();
+    expect(screen.queryByText(/deana-follow-ups/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Explain coverage" }));
+
+    await waitFor(() => expect(screen.getByText("What does partial coverage mean in this report?")).toBeInTheDocument());
+  });
+
   it("appends another page when the user loads more category results", async () => {
     const user = userEvent.setup();
     storedProfiles = [makePaginatedProfile("profile-5", 55)];

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -734,6 +734,15 @@ describe("Deana app", () => {
     renderApp("/explorer/profile-ai?tab=ai");
 
     await screen.findByText(/AI chat sends report context off this device/i);
+    const explorerNav = within(screen.getByRole("navigation", { name: "Explorer sections" }));
+    const explorerNavLabels = explorerNav.getAllByRole("button").map((button) => button.textContent);
+    expect(explorerNavLabels).toEqual([
+      "Overview",
+      "AI Chat",
+      "Medical",
+      "Traits",
+      "Drug response",
+    ]);
     expect(fetchCallsFor("/api/ai-status").length).toBeGreaterThan(0);
     expect(fetchCallsFor("/api/chat")).toHaveLength(0);
 
@@ -765,7 +774,7 @@ describe("Deana app", () => {
 
     await screen.findByText("Current report");
     await waitFor(() => expect(screen.getByTestId("location").textContent).toContain("tab=overview"));
-    expect(screen.queryByRole("button", { name: "AI" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "AI Chat" })).not.toBeInTheDocument();
   });
 
   it("shows chat privacy details from the empty-state learn more button without the old banner", async () => {

--- a/src/components/deana/aiChat.test.ts
+++ b/src/components/deana/aiChat.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import type { ChatRetrievalTrace } from "../../types";
 import { compactChatMessagesForRequest, generatingStatusDetail, searchMoreFollowUpFromTrace, traceFindingSummary, type SearchStatus } from "./aiChat";
+
+const emptySearchTrace: ChatRetrievalTrace = {
+  searchedAt: "2026-05-01T12:00:00.000Z",
+  scannedCategories: ["medical"],
+  searchedTerms: ["zymase"],
+  relatedTerms: [],
+  resultCount: 0,
+  returnedFindings: [],
+  rationale: "No saved report findings matched.",
+};
 
 describe("generatingStatusDetail", () => {
   it("uses a generic thinking label until report context search is requested", () => {
@@ -23,6 +35,13 @@ describe("generatingStatusDetail", () => {
     expect(generatingStatusDetail({ status: "searching" })).toBe("Searching saved report findings...");
     expect(generatingStatusDetail(readyStatus)).toBe("Interpreting 3 matched findings...");
     expect(generatingStatusDetail({ status: "error", message: "Search failed." })).toBe("Search failed.");
+  });
+
+  it("uses a neutral label when local report search finds nothing", () => {
+    expect(generatingStatusDetail({
+      status: "ready",
+      trace: emptySearchTrace,
+    })).toBe("No matching saved findings found...");
   });
 });
 
@@ -53,6 +72,97 @@ describe("compactChatMessagesForRequest", () => {
         id: "assistant-1",
         role: "assistant",
         parts: [{ type: "text", text: "Here is the comparison." }],
+      },
+    ]);
+  });
+
+  it("keeps the latest completed tool output so automatic continuation can see empty search results", () => {
+    const completedToolPart: UIMessage["parts"][number] = {
+      type: "tool-searchReportFindings",
+      state: "output-available",
+      toolCallId: "tool-empty",
+      input: {
+        query: "zymase tolerance",
+        categories: [],
+        genes: [],
+        rsids: [],
+        topics: [],
+        conditions: [],
+        relatedTerms: ["zymase"],
+        evidence: [],
+        rationale: "Search report terms from the prompt.",
+      },
+      output: {
+        findings: [],
+        trace: emptySearchTrace,
+        resultCount: 0,
+        message: "No saved report findings matched this local browser search.",
+      },
+    };
+
+    expect(compactChatMessagesForRequest([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Anything about zymase tolerance?" }],
+      },
+      {
+        id: "assistant-tool-1",
+        role: "assistant",
+        parts: [completedToolPart],
+      },
+    ])).toEqual([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Anything about zymase tolerance?" }],
+      },
+      {
+        id: "assistant-tool-1",
+        role: "assistant",
+        parts: [completedToolPart],
+      },
+    ]);
+  });
+
+  it("strips old tool-only messages after the assistant has answered", () => {
+    const oldToolPart: UIMessage["parts"][number] = {
+      type: "tool-searchReportFindings",
+      state: "output-available",
+      toolCallId: "tool-old",
+      input: {},
+      output: {
+        findings: [{ detail: "old compact finding payload" }],
+        resultCount: 1,
+      },
+    };
+
+    expect(compactChatMessagesForRequest([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Anything about factor v?" }],
+      },
+      {
+        id: "assistant-tool-1",
+        role: "assistant",
+        parts: [oldToolPart],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "I found one matching saved finding." }],
+      },
+    ])).toEqual([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Anything about factor v?" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "I found one matching saved finding." }],
       },
     ]);
   });

--- a/src/components/deana/aiChat.test.ts
+++ b/src/components/deana/aiChat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { generatingStatusDetail, type SearchStatus } from "./aiChat";
+import { compactChatMessagesForRequest, generatingStatusDetail, searchMoreFollowUpFromTrace, traceFindingSummary, type SearchStatus } from "./aiChat";
 
 describe("generatingStatusDetail", () => {
   it("uses a generic thinking label until report context search is requested", () => {
@@ -23,5 +23,118 @@ describe("generatingStatusDetail", () => {
     expect(generatingStatusDetail({ status: "searching" })).toBe("Searching saved report findings...");
     expect(generatingStatusDetail(readyStatus)).toBe("Interpreting 3 matched findings...");
     expect(generatingStatusDetail({ status: "error", message: "Search failed." })).toBe("Search failed.");
+  });
+});
+
+describe("compactChatMessagesForRequest", () => {
+  it("keeps only visible text and strips reasoning, tool outputs, and hidden follow-ups", () => {
+    expect(compactChatMessagesForRequest([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Compare these findings" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "reasoning", text: "private model reasoning" },
+          { type: "tool-searchReportFindings", state: "output-available", toolCallId: "tool-1", input: {}, output: { findings: [{ detail: "large finding payload" }] } },
+          { type: "text", text: 'Here is the comparison.\n<!-- deana-follow-ups: [{"title":"Next","body":"Ask next"}] -->' },
+        ],
+      },
+    ])).toEqual([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Compare these findings" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Here is the comparison." }],
+      },
+    ]);
+  });
+});
+
+describe("traceFindingSummary", () => {
+  it("shows interpreted findings and remaining local matches instead of the candidate window ratio", () => {
+    expect(traceFindingSummary({
+      searchedAt: "2026-05-01T12:00:00.000Z",
+      scannedCategories: ["medical"],
+      searchedTerms: ["factor v"],
+      relatedTerms: [],
+      resultCount: 18,
+      sentCount: 18,
+      candidateWindowCount: 180,
+      remainingCandidateCount: 162,
+      returnedFindings: [],
+      rationale: "Matched medical findings.",
+    }, 18)).toBe("18 findings interpreted · 162 remaining");
+  });
+
+  it("omits the remaining count when there are no more local matches in the window", () => {
+    expect(traceFindingSummary({
+      searchedAt: "2026-05-01T12:00:00.000Z",
+      scannedCategories: ["traits"],
+      searchedTerms: ["baldness"],
+      relatedTerms: [],
+      resultCount: 1,
+      sentCount: 1,
+      remainingCandidateCount: 0,
+      returnedFindings: [],
+      rationale: "Matched trait findings.",
+    }, 1)).toBe("1 finding interpreted");
+  });
+});
+
+describe("searchMoreFollowUpFromTrace", () => {
+  it("builds the local search-more follow-up only when more findings remain", () => {
+    expect(searchMoreFollowUpFromTrace({
+      searchedAt: "2026-05-01T12:00:00.000Z",
+      scannedCategories: ["medical"],
+      searchedTerms: ["factor v"],
+      relatedTerms: [],
+      resultCount: 8,
+      sentCount: 8,
+      remainingCandidateCount: 12,
+      returnedFindings: [],
+      rationale: "Matched medical findings.",
+      searchPlan: {
+        query: "Factor V",
+        categories: ["medical"],
+        genes: [],
+        rsids: [],
+        topics: [],
+        conditions: [],
+        relatedTerms: [],
+        evidence: [],
+        rationale: "Find Factor V entries.",
+      },
+      retrievalCursor: {
+        hasMore: true,
+        nextOffset: 8,
+        sentFindingIds: ["medical-1"],
+      },
+    })).toEqual({
+      title: "Search more findings",
+      body: "Show me more local findings for Factor V.",
+    });
+
+    expect(searchMoreFollowUpFromTrace({
+      searchedAt: "2026-05-01T12:00:00.000Z",
+      scannedCategories: ["traits"],
+      searchedTerms: ["hair"],
+      relatedTerms: [],
+      resultCount: 1,
+      returnedFindings: [],
+      rationale: "Matched trait findings.",
+      retrievalCursor: {
+        hasMore: false,
+        nextOffset: 1,
+        sentFindingIds: ["traits-1"],
+      },
+    })).toBeNull();
   });
 });

--- a/src/components/deana/aiChat.tsx
+++ b/src/components/deana/aiChat.tsx
@@ -9,13 +9,15 @@ import type { ExplorerFilters } from "../../lib/explorer";
 import {
   buildChatContext,
   CHAT_CONSENT_VERSION,
+  extractChatFollowUps,
   formatChatTitle,
   mergeChatFindings,
+  normalizeChatFollowUps,
   type ChatContextFinding,
+  type ChatFollowUpSuggestion,
   type ChatReportContext,
-  type ChatSearchPlan,
 } from "../../lib/aiChat";
-import { searchReportEntriesForChat } from "../../lib/aiRetrieval";
+import { searchReportEntriesForChat, type ChatRetrievalResult } from "../../lib/aiRetrieval";
 import {
   loadAiConsent,
   loadChatMessages,
@@ -29,7 +31,7 @@ import {
   saveChatMessages,
   saveChatThread,
 } from "../../lib/storage";
-import type { ChatRetrievalTrace, ExplorerTab, ProfileMeta, StoredChatMessage, StoredChatThread, StoredReportEntry } from "../../types";
+import type { ChatRetrievalTrace, ChatSearchPlan, ExplorerTab, ProfileMeta, StoredChatMessage, StoredChatThread, StoredReportEntry } from "../../types";
 import { FindingInspector } from "./explorer";
 import { Icon } from "./ui";
 
@@ -59,6 +61,10 @@ type ChatPanel =
   | { mode: "findings" }
   | { mode: "inspector"; findingId: string; finding: StoredReportEntry | null; isLoading: boolean; error: string | null };
 
+type ChatFollowUpAction =
+  | { kind: "prompt"; title: string; body: string }
+  | { kind: "searchMore"; title: string; body: string; trace: ChatRetrievalTrace };
+
 const entryLinkPrefix = "deana://entry/";
 const entryLinkPattern = new RegExp(`${entryLinkPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[A-Za-z0-9_%~-]+`, "g");
 
@@ -71,6 +77,25 @@ function messageText(message: UIMessage): string {
     .filter((part) => part.type === "text")
     .map((part) => "text" in part ? part.text : "")
     .join("");
+}
+
+function displayMessageText(message: UIMessage): string {
+  const text = messageText(message);
+  return message.role === "assistant" ? extractChatFollowUps(text).content : text;
+}
+
+export function compactChatMessagesForRequest(messages: UIMessage[]): UIMessage[] {
+  return messages
+    .map((message) => {
+      const text = displayMessageText(message).trim();
+
+      return {
+        id: message.id,
+        role: message.role,
+        parts: text ? [{ type: "text" as const, text }] : [],
+      };
+    })
+    .filter((message) => message.role === "user" || message.parts.length > 0);
 }
 
 function messageReasoning(message: UIMessage): string | null {
@@ -214,6 +239,52 @@ function restoredContextFindings(messages: StoredChatMessage[]): ChatContextFind
   );
 }
 
+export function searchMoreFollowUpFromTrace(trace: ChatRetrievalTrace | undefined): ChatFollowUpSuggestion | null {
+  if (!trace?.retrievalCursor?.hasMore || !trace.searchPlan) return null;
+  const label = trace.searchPlan.query.trim() || "the previous local search";
+
+  return {
+    title: "Search more findings",
+    body: `Show me more local findings for ${label}.`,
+  };
+}
+
+function followUpsForMessage(message: UIMessage, storedFollowUps: ChatFollowUpSuggestion[] | undefined): ChatFollowUpSuggestion[] {
+  return normalizeChatFollowUps([
+    ...(storedFollowUps ?? []),
+    ...extractChatFollowUps(messageText(message)).followUps,
+  ]);
+}
+
+function buildFollowUpActions({
+  message,
+  storedFollowUps,
+  trace,
+}: {
+  message: UIMessage | null;
+  storedFollowUps?: ChatFollowUpSuggestion[];
+  trace?: ChatRetrievalTrace;
+}): ChatFollowUpAction[] {
+  if (!message || message.role !== "assistant") return [];
+  const actions: ChatFollowUpAction[] = [];
+  const seenBodies = new Set<string>();
+  const searchMore = searchMoreFollowUpFromTrace(trace);
+
+  if (searchMore && trace) {
+    actions.push({ kind: "searchMore", trace, ...searchMore });
+    seenBodies.add(searchMore.body.toLocaleLowerCase());
+  }
+
+  for (const followUp of followUpsForMessage(message, storedFollowUps)) {
+    const key = followUp.body.toLocaleLowerCase();
+    if (seenBodies.has(key)) continue;
+    seenBodies.add(key);
+    actions.push({ kind: "prompt", ...followUp });
+  }
+
+  return actions.slice(0, 4);
+}
+
 export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const latestPropsRef = useRef(props);
   const latestFindingsRef = useRef<ChatReportContext["findings"]>([]);
@@ -221,6 +292,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const contextFindingsByMessageRef = useRef<Record<string, ChatContextFinding[]>>({});
   const createdAtByMessageRef = useRef<Record<string, string>>({});
   const reasoningByMessageRef = useRef<Record<string, string>>({});
+  const followUpsByMessageRef = useRef<Record<string, ChatFollowUpSuggestion[]>>({});
   const pendingTraceRef = useRef<ChatRetrievalTrace | null>(null);
   const pendingFindingsRef = useRef<ChatContextFinding[] | null>(null);
   const activeThreadRef = useRef<StoredChatThread | null>(null);
@@ -232,6 +304,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const [initialMessages, setInitialMessages] = useState<UIMessage[]>([]);
   const [input, setInput] = useState("");
   const [searchStatus, setSearchStatus] = useState<SearchStatus>({ status: "idle" });
+  const [isLoadingMoreFindings, setIsLoadingMoreFindings] = useState(false);
   const [isThreadListOpen, setIsThreadListOpen] = useState(true);
   const [isThreadPanelCollapsed, setIsThreadPanelCollapsed] = useState(false);
   const [modal, setModal] = useState<"chatPrivacy" | null>(null);
@@ -321,9 +394,15 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
         .filter((message) => message.reasoningSummary)
         .map((message) => [message.id, message.reasoningSummary as string]),
     );
+    followUpsByMessageRef.current = Object.fromEntries(
+      storedMessages
+        .filter((message) => message.followUps?.length)
+        .map((message) => [message.id, normalizeChatFollowUps(message.followUps)]),
+    );
     latestFindingsRef.current = restoredContextFindings(storedMessages);
     pendingTraceRef.current = null;
     pendingFindingsRef.current = null;
+    setIsLoadingMoreFindings(false);
     activeThreadRef.current = thread;
     isActiveThreadSavedRef.current = true;
     setPanel(null);
@@ -375,9 +454,11 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     contextFindingsByMessageRef.current = {};
     createdAtByMessageRef.current = {};
     reasoningByMessageRef.current = {};
+    followUpsByMessageRef.current = {};
     latestFindingsRef.current = [];
     pendingTraceRef.current = null;
     pendingFindingsRef.current = null;
+    setIsLoadingMoreFindings(false);
     setInitialMessages([]);
     setMessagesRef.current?.([]);
     setSearchStatus({ status: "idle" });
@@ -454,37 +535,46 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       .map((value) => Date.parse(value))
       .filter(Number.isFinite);
     let nextCreatedAtTime = Math.max(Date.now(), ...knownTimes) + 1;
-    const assistantText = assistantMessage ? messageText(assistantMessage).trim() : "";
+    const assistantParsed = assistantMessage ? extractChatFollowUps(messageText(assistantMessage)) : null;
+    const assistantText = assistantParsed?.content.trim() ?? "";
     const assistantTrace = assistantMessage && assistantText && pendingTraceRef.current ? pendingTraceRef.current : null;
     const assistantFindings = assistantMessage && assistantText && pendingFindingsRef.current ? pendingFindingsRef.current : null;
     const assistantReasoning = assistantMessage ? messageReasoning(assistantMessage) : null;
+    const assistantFollowUps = assistantParsed ? normalizeChatFollowUps(assistantParsed.followUps) : [];
 
     return messages
       .filter((message) => {
         if (message.role === "user") return true;
         if (message.role !== "assistant") return false;
-        return Boolean(messageText(message).trim() || messageReasoning(message) || traceByMessageRef.current[message.id] || contextFindingsByMessageRef.current[message.id]?.length);
+        return Boolean(displayMessageText(message).trim() || messageReasoning(message) || traceByMessageRef.current[message.id] || contextFindingsByMessageRef.current[message.id]?.length);
       })
       .map((message) => {
+        const parsedMessage = message.role === "assistant" ? extractChatFollowUps(messageText(message)) : null;
+        const content = parsedMessage?.content ?? messageText(message);
         const existingCreatedAt = createdAtByMessageRef.current[message.id];
         const createdAt = existingCreatedAt ?? new Date(nextCreatedAtTime++).toISOString();
         createdAtByMessageRef.current[message.id] = createdAt;
         const trace = message.id === assistantMessage?.id && assistantTrace ? assistantTrace : traceByMessageRef.current[message.id];
         const contextFindings = message.id === assistantMessage?.id && assistantFindings ? assistantFindings : contextFindingsByMessageRef.current[message.id];
+        const followUps = message.id === assistantMessage?.id && assistantFollowUps.length > 0
+          ? assistantFollowUps
+          : followUpsByMessageRef.current[message.id];
         if (trace) traceByMessageRef.current[message.id] = trace;
         if (contextFindings?.length) contextFindingsByMessageRef.current[message.id] = contextFindings;
         if (message.id === assistantMessage?.id && assistantReasoning) reasoningByMessageRef.current[message.id] = assistantReasoning;
+        if (followUps?.length) followUpsByMessageRef.current[message.id] = followUps;
 
         return {
           id: message.id,
           threadId: activeThreadRef.current?.id ?? "",
           profileId: props.profile.id,
           role: message.role as "user" | "assistant",
-          content: messageText(message),
+          content,
           createdAt,
           trace,
           contextFindings,
           reasoningSummary: message.id === assistantMessage?.id ? assistantReasoning : null,
+          followUps,
         };
       });
   }
@@ -501,7 +591,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
             version: CHAT_CONSENT_VERSION,
           },
           context: buildChatContext({ ...latestPropsRef.current, retrievedFindings: latestFindingsRef.current }),
-          messages,
+          messages: compactChatMessagesForRequest(messages),
         },
       };
     },
@@ -533,13 +623,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
           prompt: plan.query,
           plan,
         });
-        latestFindingsRef.current = mergeChatFindings([
-          ...retrieval.findings,
-          ...latestFindingsRef.current,
-        ]);
-        pendingTraceRef.current = retrieval.trace;
-        pendingFindingsRef.current = latestFindingsRef.current;
-        setSearchStatus({ status: "ready", trace: retrieval.trace });
+        applyChatRetrieval(retrieval);
         void addToolOutput({
           tool: "searchReportFindings",
           toolCallId: toolCall.toolCallId,
@@ -563,7 +647,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     onFinish: async ({ message, messages: finishedMessages }) => {
       const thread = activeThreadRef.current;
       if (!thread) return;
-      if (message.role === "assistant" && hasToolPart(message) && !messageText(message).trim()) return;
+      if (message.role === "assistant" && hasToolPart(message) && !displayMessageText(message).trim()) return;
       const now = new Date().toISOString();
       const nextThread = {
         ...thread,
@@ -604,6 +688,51 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     return () => window.cancelAnimationFrame(frameId);
   }, [messageScrollSignal, status, searchStatus.status, error?.message]);
 
+  function applyChatRetrieval(retrieval: ChatRetrievalResult) {
+    latestFindingsRef.current = mergeChatFindings([
+      ...retrieval.findings,
+      ...latestFindingsRef.current,
+    ]);
+    pendingTraceRef.current = retrieval.trace;
+    pendingFindingsRef.current = latestFindingsRef.current;
+    setSearchStatus({ status: "ready", trace: retrieval.trace });
+  }
+
+  async function handleShowMoreFindings(trace: ChatRetrievalTrace, followUpPrompt?: string) {
+    const cursor = trace.retrievalCursor;
+    const plan = trace.searchPlan;
+    if (!cursor?.hasMore || !plan || isBusy || isLoadingMoreFindings) return;
+
+    setIsLoadingMoreFindings(true);
+    setSearchStatus({ status: "searching" });
+
+    try {
+      const retrieval = await searchReportEntriesForChat({
+        profileId: latestPropsRef.current.profile.id,
+        prompt: plan.query,
+        plan,
+        excludeIds: cursor.sentFindingIds,
+        offset: cursor.nextOffset,
+      });
+
+      if (retrieval.findings.length === 0) {
+        setSearchStatus({ status: "error", message: "No additional local findings matched that search." });
+        return;
+      }
+
+      applyChatRetrieval(retrieval);
+      setPanel({ mode: "findings" });
+
+      const label = plan.query.trim() || "the previous local search";
+      await sendMessage({ text: followUpPrompt ?? `Show me more local findings for ${label}.` });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not retrieve more local findings.";
+      setSearchStatus({ status: "error", message });
+    } finally {
+      setIsLoadingMoreFindings(false);
+    }
+  }
+
   function resizeInput() {
     const node = inputRef.current;
     if (!node) return;
@@ -643,6 +772,16 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     }
     setIsThreadListOpen(false);
     await sendMessage({ text });
+  }
+
+  async function sendFollowUp(action: ChatFollowUpAction) {
+    if (isBusy) return;
+    clearError();
+    if (action.kind === "searchMore") {
+      await handleShowMoreFindings(action.trace, action.body);
+      return;
+    }
+    await sendPreparedMessage(action.body);
   }
 
   function handleComposerKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
@@ -717,7 +856,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   }, []);
 
   const linkedEntryIds = useMemo(() => {
-    return linkedEntryIdsFromTextValues(messages.map(messageText));
+    return linkedEntryIdsFromTextValues(messages.map(displayMessageText));
   }, [messages]);
 
   const entryTitleById = useMemo(() => {
@@ -798,6 +937,16 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     (entryId: string) => void openEntryPanel(`deana://entry/${encodeURIComponent(entryId)}`),
     [],
   );
+  const latestAssistantMessage = messages
+    .slice()
+    .reverse()
+    .find((message) => message.role === "assistant" && displayMessageText(message).trim()) ?? null;
+  const latestAssistantTrace = latestAssistantMessage ? traceByMessageRef.current[latestAssistantMessage.id] : undefined;
+  const followUpActions = isBusy ? [] : buildFollowUpActions({
+    message: latestAssistantMessage,
+    storedFollowUps: latestAssistantMessage ? followUpsByMessageRef.current[latestAssistantMessage.id] : undefined,
+    trace: latestAssistantTrace,
+  });
 
   return (
     <section
@@ -854,9 +1003,10 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
                 <ChatMessage
                   key={message.id}
                   role={message.role}
-                  content={messageText(message)}
+                  content={displayMessageText(message)}
                   modelName={messageModel(message)}
                   trace={traceByMessageRef.current[message.id]}
+                  interpretedFindingCount={contextFindingsByMessageRef.current[message.id]?.length}
                   reasoningSummary={messageReasoning(message) ?? reasoningByMessageRef.current[message.id] ?? null}
                   entryTitleById={entryTitleById}
                   components={markdownComponents}
@@ -873,6 +1023,9 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
               ) : null}
             </div>
             <form className="dn-ai-form" onSubmit={submitMessage}>
+              {followUpActions.length > 0 ? (
+                <FollowUpSuggestions followUps={followUpActions} onSelect={(action) => void sendFollowUp(action)} />
+              ) : null}
               <div className="dn-ai-composer">
                 <textarea
                   ref={inputRef}
@@ -910,6 +1063,8 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
           onClose={() => setPanel(null)}
           onBack={() => setPanel({ mode: "findings" })}
           onOpenEntry={handleOpenEntry}
+          onShowMoreFindings={handleShowMoreFindings}
+          isLoadingMoreFindings={isLoadingMoreFindings}
         />
       ) : null}
       {modal === "chatPrivacy" ? <ChatPrivacyModal onClose={() => setModal(null)} /> : null}
@@ -926,6 +1081,25 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
         />
       ) : null}
     </section>
+  );
+}
+
+function FollowUpSuggestions({
+  followUps,
+  onSelect,
+}: {
+  followUps: ChatFollowUpAction[];
+  onSelect: (action: ChatFollowUpAction) => void;
+}) {
+  return (
+    <div className="dn-ai-follow-ups" aria-label="Suggested follow-up prompts">
+      {followUps.map((followUp) => (
+        <button key={`${followUp.kind}-${followUp.body}`} type="button" onClick={() => onSelect(followUp)} title={followUp.body}>
+          {followUp.kind === "searchMore" ? <Icon name="search" /> : <Icon name="spark" />}
+          <span>{followUp.title}</span>
+        </button>
+      ))}
+    </div>
   );
 }
 
@@ -1025,6 +1199,22 @@ export function generatingStatusDetail(status: SearchStatus): string {
   if (status.status === "ready") return `Interpreting ${status.trace.resultCount} matched findings...`;
   if (status.status === "error") return status.message;
   return "Thinking…";
+}
+
+function findingCountLabel(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? "finding" : "findings"}`;
+}
+
+export function traceFindingSummary(trace: ChatRetrievalTrace, interpretedFindingCount?: number): string {
+  const interpretedCount = interpretedFindingCount ?? trace.sentCount ?? trace.resultCount;
+  const remainingCount = trace.remainingCandidateCount ?? 0;
+  const interpretedLabel = `${findingCountLabel(interpretedCount)} interpreted`;
+
+  if (remainingCount > 0) {
+    return `${interpretedLabel} · ${remainingCount.toLocaleString()} remaining`;
+  }
+
+  return interpretedLabel;
 }
 
 function GeneratingStatus({ status }: { status: SearchStatus }) {
@@ -1147,6 +1337,8 @@ function ChatSidePanel({
   onClose,
   onBack,
   onOpenEntry,
+  onShowMoreFindings,
+  isLoadingMoreFindings,
 }: {
   panel: ChatPanel;
   traces: ChatRetrievalTrace[];
@@ -1154,6 +1346,8 @@ function ChatSidePanel({
   onClose: () => void;
   onBack: () => void;
   onOpenEntry: (entryId: string) => void;
+  onShowMoreFindings: (trace: ChatRetrievalTrace) => void;
+  isLoadingMoreFindings: boolean;
 }) {
   const effectiveTraces = searchStatus.status === "ready"
     ? [...traces.filter((trace) => trace.searchedAt !== searchStatus.trace.searchedAt), searchStatus.trace]
@@ -1182,10 +1376,17 @@ function ChatSidePanel({
                 <h3>Searched {latestTrace.scannedCategories.join(", ")}</h3>
                 <p>{latestTrace.rationale}</p>
                 <dl>
-                  <div><dt>Matched</dt><dd>{latestTrace.resultCount.toLocaleString()} findings</dd></div>
+                  <div><dt>Sent</dt><dd>{(latestTrace.sentCount ?? latestTrace.resultCount).toLocaleString()} findings</dd></div>
+                  <div><dt>Considered</dt><dd>{(latestTrace.candidateWindowCount ?? latestTrace.indexCandidateCount ?? latestTrace.resultCount).toLocaleString()} local matches</dd></div>
+                  <div><dt>Remaining</dt><dd>{(latestTrace.remainingCandidateCount ?? 0).toLocaleString()} in this local window</dd></div>
                   <div><dt>Terms</dt><dd>{latestTrace.searchedTerms.length > 0 ? latestTrace.searchedTerms.slice(0, 16).join(", ") : "Prompt terms only"}</dd></div>
                   <div><dt>Related</dt><dd>{latestTrace.relatedTerms.length > 0 ? latestTrace.relatedTerms.slice(0, 12).join(", ") : "None returned"}</dd></div>
                 </dl>
+                {latestTrace.retrievalCursor?.hasMore ? (
+                  <button className="dn-button dn-button--primary dn-ai-show-more-button" type="button" onClick={() => onShowMoreFindings(latestTrace)} disabled={isLoadingMoreFindings}>
+                    <Icon name="search" /> {isLoadingMoreFindings ? "Finding more..." : "Show more findings"}
+                  </button>
+                ) : null}
               </section>
               <section>
                 <p className="dn-eyebrow">Sent to AI</p>
@@ -1229,6 +1430,7 @@ const ChatMessage = memo(function ChatMessage({
   content,
   modelName,
   trace,
+  interpretedFindingCount,
   reasoningSummary,
   entryTitleById,
   components,
@@ -1239,6 +1441,7 @@ const ChatMessage = memo(function ChatMessage({
   content: string;
   modelName: string | null;
   trace?: ChatRetrievalTrace;
+  interpretedFindingCount?: number;
   reasoningSummary: string | null;
   entryTitleById: Map<string, string>;
   components: Components;
@@ -1265,7 +1468,7 @@ const ChatMessage = memo(function ChatMessage({
         </ReactMarkdown>
       ) : null}
       {role === "assistant" && trace ? (
-        <TracePanel trace={trace} onOpenFindings={onOpenFindings} />
+        <TracePanel trace={trace} interpretedFindingCount={interpretedFindingCount} onOpenFindings={onOpenFindings} />
       ) : null}
     </article>
   );
@@ -1284,15 +1487,17 @@ function ModelReasoning({ reasoning }: { reasoning: string }) {
 
 function TracePanel({
   trace,
+  interpretedFindingCount,
   onOpenFindings,
 }: {
   trace: ChatRetrievalTrace;
+  interpretedFindingCount?: number;
   onOpenFindings: () => void;
 }) {
   return (
     <button className="dn-ai-findings-button" type="button" onClick={onOpenFindings}>
       <Icon name="search" />
-      {trace.resultCount.toLocaleString()} matching findings sent
+      {traceFindingSummary(trace, interpretedFindingCount)}
     </button>
   );
 }

--- a/src/components/deana/aiChat.tsx
+++ b/src/components/deana/aiChat.tsx
@@ -72,6 +72,7 @@ interface ParsedChatMessage {
 
 const entryLinkPrefix = "deana://entry/";
 const entryLinkPattern = new RegExp(`${entryLinkPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[A-Za-z0-9_%~-]+`, "g");
+const noSavedReportFindingsMessage = "No saved report findings matched this local browser search.";
 
 function makeId(prefix: string): string {
   return `${prefix}-${typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
@@ -97,15 +98,39 @@ function displayMessageText(message: UIMessage): string {
   return parseChatMessage(message).content;
 }
 
+function isSettledSearchToolPart(part: UIMessage["parts"][number]): boolean {
+  return part.type === "tool-searchReportFindings"
+    && "state" in part
+    && (part.state === "output-available" || part.state === "output-error");
+}
+
+function shouldKeepLatestToolResult(
+  message: UIMessage,
+  index: number,
+  messages: UIMessage[],
+  text: string,
+  settledSearchToolParts: UIMessage["parts"],
+): boolean {
+  return index === messages.length - 1
+    && message.role === "assistant"
+    && !text
+    && settledSearchToolParts.length > 0;
+}
+
 export function compactChatMessagesForRequest(messages: UIMessage[]): UIMessage[] {
   return messages
-    .map((message) => {
+    .map((message, index) => {
       const text = displayMessageText(message).trim();
+      const settledSearchToolParts = message.parts.filter(isSettledSearchToolPart);
+      const parts: UIMessage["parts"] = text ? [{ type: "text" as const, text }] : [];
+      if (shouldKeepLatestToolResult(message, index, messages, text, settledSearchToolParts)) {
+        parts.push(...settledSearchToolParts);
+      }
 
       return {
         id: message.id,
         role: message.role,
-        parts: text ? [{ type: "text" as const, text }] : [],
+        parts,
       };
     })
     .filter((message) => message.role === "user" || message.parts.length > 0);
@@ -647,6 +672,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
             findings: retrieval.findings,
             trace: retrieval.trace,
             resultCount: retrieval.resultCount,
+            ...(retrieval.resultCount === 0 ? { message: noSavedReportFindingsMessage } : {}),
           },
         });
       } catch (error) {
@@ -1116,14 +1142,52 @@ function FollowUpSuggestions({
   followUps: ChatFollowUpAction[];
   onSelect: (action: ChatFollowUpAction) => void;
 }) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const [scrollEdges, setScrollEdges] = useState({ left: false, right: false });
+  const followUpSignature = followUps.map((followUp) => `${followUp.kind}:${followUp.title}:${followUp.body}`).join("\n");
+  const updateScrollEdges = useCallback(() => {
+    const node = scrollerRef.current;
+    if (!node) return;
+    const maxScrollLeft = node.scrollWidth - node.clientWidth;
+    const nextEdges = {
+      left: node.scrollLeft > 1,
+      right: node.scrollLeft < maxScrollLeft - 1,
+    };
+    setScrollEdges((current) => (
+      current.left === nextEdges.left && current.right === nextEdges.right ? current : nextEdges
+    ));
+  }, []);
+
+  useEffect(() => {
+    const node = scrollerRef.current;
+    if (!node) return;
+    const frameId = window.requestAnimationFrame(updateScrollEdges);
+    node.addEventListener("scroll", updateScrollEdges, { passive: true });
+    window.addEventListener("resize", updateScrollEdges);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      node.removeEventListener("scroll", updateScrollEdges);
+      window.removeEventListener("resize", updateScrollEdges);
+    };
+  }, [followUpSignature, updateScrollEdges]);
+
+  const shellClassName = [
+    "dn-ai-follow-up-shell",
+    scrollEdges.left ? "has-left-fade" : "",
+    scrollEdges.right ? "has-right-fade" : "",
+  ].filter(Boolean).join(" ");
+
   return (
-    <div className="dn-ai-follow-ups" aria-label="Suggested follow-up prompts">
-      {followUps.map((followUp) => (
-        <button key={`${followUp.kind}-${followUp.body}`} type="button" onClick={() => onSelect(followUp)} title={followUp.body}>
-          {followUp.kind === "searchMore" ? <Icon name="search" /> : <Icon name="spark" />}
-          <span>{followUp.title}</span>
-        </button>
-      ))}
+    <div className={shellClassName}>
+      <div ref={scrollerRef} className="dn-ai-follow-ups" aria-label="Suggested follow-up prompts">
+        {followUps.map((followUp) => (
+          <button key={`${followUp.kind}-${followUp.body}`} type="button" onClick={() => onSelect(followUp)} title={followUp.body}>
+            {followUp.kind === "searchMore" ? <Icon name="search" /> : <Icon name="spark" />}
+            <span>{followUp.title}</span>
+          </button>
+        ))}
+      </div>
     </div>
   );
 }
@@ -1221,6 +1285,7 @@ function ThreadList({
 
 export function generatingStatusDetail(status: SearchStatus): string {
   if (status.status === "searching") return "Searching saved report findings...";
+  if (status.status === "ready" && status.trace.resultCount === 0) return "No matching saved findings found...";
   if (status.status === "ready") return `Interpreting ${status.trace.resultCount} matched findings...`;
   if (status.status === "error") return status.message;
   return "Thinking…";

--- a/src/components/deana/aiChat.tsx
+++ b/src/components/deana/aiChat.tsx
@@ -62,8 +62,13 @@ type ChatPanel =
   | { mode: "inspector"; findingId: string; finding: StoredReportEntry | null; isLoading: boolean; error: string | null };
 
 type ChatFollowUpAction =
-  | { kind: "prompt"; title: string; body: string }
-  | { kind: "searchMore"; title: string; body: string; trace: ChatRetrievalTrace };
+  | ({ kind: "prompt" } & ChatFollowUpSuggestion)
+  | ({ kind: "searchMore"; trace: ChatRetrievalTrace } & ChatFollowUpSuggestion);
+
+interface ParsedChatMessage {
+  content: string;
+  followUps: ChatFollowUpSuggestion[];
+}
 
 const entryLinkPrefix = "deana://entry/";
 const entryLinkPattern = new RegExp(`${entryLinkPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[A-Za-z0-9_%~-]+`, "g");
@@ -79,9 +84,17 @@ function messageText(message: UIMessage): string {
     .join("");
 }
 
-function displayMessageText(message: UIMessage): string {
+function parseChatMessage(message: UIMessage): ParsedChatMessage {
   const text = messageText(message);
-  return message.role === "assistant" ? extractChatFollowUps(text).content : text;
+  if (message.role !== "assistant") {
+    return { content: text, followUps: [] };
+  }
+
+  return extractChatFollowUps(text);
+}
+
+function displayMessageText(message: UIMessage): string {
+  return parseChatMessage(message).content;
 }
 
 export function compactChatMessagesForRequest(messages: UIMessage[]): UIMessage[] {
@@ -241,19 +254,22 @@ function restoredContextFindings(messages: StoredChatMessage[]): ChatContextFind
 
 export function searchMoreFollowUpFromTrace(trace: ChatRetrievalTrace | undefined): ChatFollowUpSuggestion | null {
   if (!trace?.retrievalCursor?.hasMore || !trace.searchPlan) return null;
-  const label = trace.searchPlan.query.trim() || "the previous local search";
 
   return {
     title: "Search more findings",
-    body: `Show me more local findings for ${label}.`,
+    body: `Show me more local findings for ${searchPlanLabel(trace.searchPlan)}.`,
   };
 }
 
 function followUpsForMessage(message: UIMessage, storedFollowUps: ChatFollowUpSuggestion[] | undefined): ChatFollowUpSuggestion[] {
   return normalizeChatFollowUps([
     ...(storedFollowUps ?? []),
-    ...extractChatFollowUps(messageText(message)).followUps,
+    ...parseChatMessage(message).followUps,
   ]);
+}
+
+function searchPlanLabel(plan: ChatSearchPlan): string {
+  return plan.query.trim() || "the previous local search";
 }
 
 function buildFollowUpActions({
@@ -535,7 +551,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       .map((value) => Date.parse(value))
       .filter(Number.isFinite);
     let nextCreatedAtTime = Math.max(Date.now(), ...knownTimes) + 1;
-    const assistantParsed = assistantMessage ? extractChatFollowUps(messageText(assistantMessage)) : null;
+    const assistantParsed = assistantMessage ? parseChatMessage(assistantMessage) : null;
     const assistantText = assistantParsed?.content.trim() ?? "";
     const assistantTrace = assistantMessage && assistantText && pendingTraceRef.current ? pendingTraceRef.current : null;
     const assistantFindings = assistantMessage && assistantText && pendingFindingsRef.current ? pendingFindingsRef.current : null;
@@ -546,11 +562,11 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       .filter((message) => {
         if (message.role === "user") return true;
         if (message.role !== "assistant") return false;
-        return Boolean(displayMessageText(message).trim() || messageReasoning(message) || traceByMessageRef.current[message.id] || contextFindingsByMessageRef.current[message.id]?.length);
+        return Boolean(parseChatMessage(message).content.trim() || messageReasoning(message) || traceByMessageRef.current[message.id] || contextFindingsByMessageRef.current[message.id]?.length);
       })
       .map((message) => {
-        const parsedMessage = message.role === "assistant" ? extractChatFollowUps(messageText(message)) : null;
-        const content = parsedMessage?.content ?? messageText(message);
+        const parsedMessage = parseChatMessage(message);
+        const content = parsedMessage.content;
         const existingCreatedAt = createdAtByMessageRef.current[message.id];
         const createdAt = existingCreatedAt ?? new Date(nextCreatedAtTime++).toISOString();
         createdAtByMessageRef.current[message.id] = createdAt;
@@ -664,6 +680,13 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   });
   setMessagesRef.current = setMessages;
   const isBusy = status === "submitted" || status === "streaming";
+  const parsedMessageById = useMemo(() => {
+    return new Map(messages.map((message) => [message.id, parseChatMessage(message)]));
+  }, [messages]);
+  const displayTextForMessage = useCallback(
+    (message: UIMessage) => parsedMessageById.get(message.id)?.content ?? displayMessageText(message),
+    [parsedMessageById],
+  );
   const messageScrollSignal = useMemo(() => messages
     .map((message) => {
       const text = messageText(message);
@@ -723,8 +746,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       applyChatRetrieval(retrieval);
       setPanel({ mode: "findings" });
 
-      const label = plan.query.trim() || "the previous local search";
-      await sendMessage({ text: followUpPrompt ?? `Show me more local findings for ${label}.` });
+      await sendMessage({ text: followUpPrompt ?? `Show me more local findings for ${searchPlanLabel(plan)}.` });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Could not retrieve more local findings.";
       setSearchStatus({ status: "error", message });
@@ -856,8 +878,8 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   }, []);
 
   const linkedEntryIds = useMemo(() => {
-    return linkedEntryIdsFromTextValues(messages.map(displayMessageText));
-  }, [messages]);
+    return linkedEntryIdsFromTextValues(messages.map(displayTextForMessage));
+  }, [displayTextForMessage, messages]);
 
   const entryTitleById = useMemo(() => {
     return buildEntryTitleById({
@@ -937,10 +959,13 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     (entryId: string) => void openEntryPanel(`deana://entry/${encodeURIComponent(entryId)}`),
     [],
   );
-  const latestAssistantMessage = messages
-    .slice()
-    .reverse()
-    .find((message) => message.role === "assistant" && displayMessageText(message).trim()) ?? null;
+  const latestAssistantMessage = (() => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (message.role === "assistant" && displayTextForMessage(message).trim()) return message;
+    }
+    return null;
+  })();
   const latestAssistantTrace = latestAssistantMessage ? traceByMessageRef.current[latestAssistantMessage.id] : undefined;
   const followUpActions = isBusy ? [] : buildFollowUpActions({
     message: latestAssistantMessage,
@@ -1003,7 +1028,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
                 <ChatMessage
                   key={message.id}
                   role={message.role}
-                  content={displayMessageText(message)}
+                  content={displayTextForMessage(message)}
                   modelName={messageModel(message)}
                   trace={traceByMessageRef.current[message.id]}
                   interpretedFindingCount={contextFindingsByMessageRef.current[message.id]?.length}

--- a/src/components/deana/aiChat.tsx
+++ b/src/components/deana/aiChat.tsx
@@ -126,6 +126,17 @@ function entryIdFromHref(href: string | undefined): string | null {
   return decodeURIComponent(href.slice(entryLinkPrefix.length));
 }
 
+function linkedEntryIdsFromTextValues(values: string[]): string[] {
+  const ids = new Set<string>();
+  values.forEach((value) => {
+    for (const match of value.matchAll(entryLinkPattern)) {
+      const entryId = entryIdFromHref(match[0]);
+      if (entryId) ids.add(entryId);
+    }
+  });
+  return Array.from(ids).sort();
+}
+
 function textFromChildren(children: ReactNode): string {
   let text = "";
   Children.forEach(children, (child) => {
@@ -234,6 +245,8 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const setMessagesRef = useRef<((messages: UIMessage[] | ((messages: UIMessage[]) => UIMessage[])) => void) | null>(null);
   const attemptedEntryTitleIdsRef = useRef<Set<string>>(new Set());
+  const entryTitleByIdRef = useRef<Map<string, string>>(new Map());
+  const openEntryPanelRef = useRef<(href: string | undefined) => void | Promise<void>>(() => undefined);
   latestPropsRef.current = props;
   activeThreadRef.current = activeThread;
 
@@ -283,6 +296,15 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
 
   async function selectThread(thread: StoredChatThread, closeList = true) {
     const storedMessages = await loadChatMessages(thread.id);
+    const linkedEntryIds = linkedEntryIdsFromTextValues(storedMessages.map((message) => message.content));
+    if (linkedEntryIds.length > 0) {
+      try {
+        const entries = await loadReportEntriesByIds(latestPropsRef.current.profile.id, linkedEntryIds);
+        cacheResolvedEntryTitles(entries);
+      } catch {
+        // Chat content should still open if optional chip title lookup fails.
+      }
+    }
     traceByMessageRef.current = Object.fromEntries(
       storedMessages
         .filter((message) => message.trace)
@@ -688,20 +710,14 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       error: finding ? null : "This finding is no longer available in the saved report.",
     });
   }, [loadChatEntry]);
+  openEntryPanelRef.current = openEntryPanel;
 
   const openFindingsPanel = useCallback(() => {
     setPanel({ mode: "findings" });
   }, []);
 
   const linkedEntryIds = useMemo(() => {
-    const ids = new Set<string>();
-    messages.forEach((message) => {
-      for (const match of messageText(message).matchAll(entryLinkPattern)) {
-        const entryId = entryIdFromHref(match[0]);
-        if (entryId) ids.add(entryId);
-      }
-    });
-    return Array.from(ids).sort();
+    return linkedEntryIdsFromTextValues(messages.map(messageText));
   }, [messages]);
 
   const entryTitleById = useMemo(() => {
@@ -715,6 +731,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       activeTrace: searchStatus.status === "ready" ? searchStatus.trace : undefined,
     });
   }, [messages, props.selectedEntry, props.visibleEntries, resolvedEntryTitles, searchStatus]);
+  entryTitleByIdRef.current = entryTitleById;
 
   useEffect(() => {
     const missingEntryIds = linkedEntryIds.filter((entryId) => !entryTitleById.has(entryId) && !attemptedEntryTitleIdsRef.current.has(entryId));
@@ -739,7 +756,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
     a({ href, children }) {
       if (entryIdFromHref(href)) {
         return (
-          <EntryChip href={href ?? ""} entryTitleById={entryTitleById} onOpenEntry={(entryHref) => void openEntryPanel(entryHref)}>
+          <EntryChip href={href ?? ""} entryTitleById={entryTitleByIdRef.current} onOpenEntry={(entryHref) => void openEntryPanelRef.current(entryHref)}>
             {children}
           </EntryChip>
         );
@@ -765,7 +782,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
         const index = match.index ?? 0;
         if (index > lastIndex) nodes.push(value.slice(lastIndex, index));
         nodes.push(
-          <EntryChip key={`${href}-${index}`} href={href} entryTitleById={entryTitleById} onOpenEntry={(entryHref) => void openEntryPanel(entryHref)}>
+          <EntryChip key={`${href}-${index}`} href={href} entryTitleById={entryTitleByIdRef.current} onOpenEntry={(entryHref) => void openEntryPanelRef.current(entryHref)}>
             {href}
           </EntryChip>,
         );
@@ -775,7 +792,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
       if (lastIndex < value.length) nodes.push(value.slice(lastIndex));
       return nodes.length > 0 ? <>{nodes}</> : <>{children}</>;
     },
-  }), [entryTitleById, openEntryPanel]);
+  }), []);
 
   const handleOpenEntry = useCallback(
     (entryId: string) => void openEntryPanel(`deana://entry/${encodeURIComponent(entryId)}`),
@@ -841,6 +858,7 @@ export function ExplorerAiChat(props: ExplorerAiChatProps) {
                   modelName={messageModel(message)}
                   trace={traceByMessageRef.current[message.id]}
                   reasoningSummary={messageReasoning(message) ?? reasoningByMessageRef.current[message.id] ?? null}
+                  entryTitleById={entryTitleById}
                   components={markdownComponents}
                   onOpenEntry={handleOpenEntry}
                   onOpenFindings={openFindingsPanel}
@@ -1212,6 +1230,7 @@ const ChatMessage = memo(function ChatMessage({
   modelName,
   trace,
   reasoningSummary,
+  entryTitleById,
   components,
   onOpenEntry,
   onOpenFindings,
@@ -1221,10 +1240,12 @@ const ChatMessage = memo(function ChatMessage({
   modelName: string | null;
   trace?: ChatRetrievalTrace;
   reasoningSummary: string | null;
+  entryTitleById: Map<string, string>;
   components: Components;
   onOpenEntry: (entryId: string) => void;
   onOpenFindings: () => void;
 }) {
+  void entryTitleById;
   const hasReasoning = Boolean(reasoningSummary?.trim());
 
   if (!content && !hasReasoning) return null;

--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -15,19 +15,23 @@ export interface ExplorerReportCard {
 
 const tabs: Array<{ id: ExplorerTab; label: string }> = [
   { id: "overview", label: "Overview" },
+  { id: "ai", label: "AI Chat" },
   { id: "medical", label: "Medical" },
   { id: "traits", label: "Traits" },
   { id: "drug", label: "Drug response" },
-  { id: "ai", label: "AI" },
 ];
 
-const nav: Array<{ id: ExplorerTab; label: string; icon: IconName }> = [
-  { id: "overview", label: "Overview", icon: "home" },
-  { id: "medical", label: "Medical", icon: "heart" },
-  { id: "traits", label: "Traits", icon: "leaf" },
-  { id: "drug", label: "Drug response", icon: "pill" },
-  { id: "ai", label: "AI", icon: "spark" },
-];
+const iconByTab: Record<ExplorerTab, IconName> = {
+  overview: "home",
+  ai: "spark",
+  medical: "heart",
+  traits: "leaf",
+  drug: "pill",
+};
+const nav: Array<{ id: ExplorerTab; label: string; icon: IconName }> = tabs.map((tab) => ({
+  ...tab,
+  icon: iconByTab[tab.id],
+}));
 const visibleTabsWithoutAi = tabs.filter((item) => item.id !== "ai");
 const visibleNavWithoutAi = nav.filter((item) => item.id !== "ai");
 const SORT_FILTER_OPTIONS: Array<[string, string]> = [

--- a/src/lib/ai/ranking.ts
+++ b/src/lib/ai/ranking.ts
@@ -1,0 +1,56 @@
+export interface RankingSignals {
+  evidenceTier: unknown;
+  outcome: unknown;
+  repute: unknown;
+}
+
+function evidenceMultiplier(evidenceTier: unknown): number {
+  switch (evidenceTier) {
+    case "high":
+      return 1.12;
+    case "moderate":
+      return 1.06;
+    case "emerging":
+      return 1;
+    case "preview":
+    case "supplementary":
+      return 0.92;
+    default:
+      return 1;
+  }
+}
+
+function outcomeMultiplier(outcome: unknown): number {
+  switch (outcome) {
+    case "negative":
+      return 1.08;
+    case "positive":
+      return 1.05;
+    case "informational":
+      return 0.97;
+    case "missing":
+      return 0.85;
+    default:
+      return 1;
+  }
+}
+
+function reputeMultiplier(repute: unknown): number {
+  switch (repute) {
+    case "bad":
+      return 1.05;
+    case "good":
+      return 1.04;
+    case "mixed":
+      return 1.03;
+    case "not-set":
+    default:
+      return 1;
+  }
+}
+
+export function rankingQualityMultiplier(signals: RankingSignals): number {
+  return evidenceMultiplier(signals.evidenceTier)
+    * outcomeMultiplier(signals.outcome)
+    * reputeMultiplier(signals.repute);
+}

--- a/src/lib/ai/searchIndex.test.ts
+++ b/src/lib/ai/searchIndex.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkerRequest, WorkerResponse } from "./searchIndexCore";
+
+const coreMocks = vi.hoisted(() => ({
+  clearSearchIndex: vi.fn(),
+  prewarmSearchIndex: vi.fn(async () => undefined),
+  queryCandidateIds: vi.fn(async () => [] as string[]),
+  searchExplorerEntryIds: vi.fn(async () => ({ ids: [], count: 0 })),
+  searchWithFields: vi.fn(async () => []),
+  waitForIndex: vi.fn(async () => undefined),
+}));
+
+vi.mock("./searchIndexCore", async (importOriginal) => ({
+  ...await importOriginal<typeof import("./searchIndexCore")>(),
+  clearSearchIndex: coreMocks.clearSearchIndex,
+  prewarmSearchIndex: coreMocks.prewarmSearchIndex,
+  queryCandidateIds: coreMocks.queryCandidateIds,
+  searchExplorerEntryIds: coreMocks.searchExplorerEntryIds,
+  searchWithFields: coreMocks.searchWithFields,
+  waitForIndex: coreMocks.waitForIndex,
+}));
+
+class MockSearchWorker {
+  static instances: MockSearchWorker[] = [];
+
+  onmessage: ((event: MessageEvent<WorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  readonly terminate = vi.fn();
+  readonly postMessage = vi.fn((message: WorkerRequest) => {
+    if (!this.autoRespond) return;
+    this.respond({ type: message.type, requestId: message.requestId } as WorkerResponse);
+  });
+
+  constructor(private readonly autoRespond = true) {
+    MockSearchWorker.instances.push(this);
+  }
+
+  respond(response: WorkerResponse): void {
+    this.onmessage?.({ data: response } as MessageEvent<WorkerResponse>);
+  }
+
+  fail(message: string): void {
+    this.onerror?.({ message } as ErrorEvent);
+  }
+}
+
+const originalWorker = globalThis.Worker;
+const profileId = "profile-1";
+
+function setGlobalWorker(value: unknown): void {
+  Object.defineProperty(globalThis, "Worker", {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function installWorker(factory: () => MockSearchWorker) {
+  const WorkerConstructor = vi.fn(function WorkerConstructor() {
+    return factory();
+  });
+  setGlobalWorker(WorkerConstructor);
+  return WorkerConstructor;
+}
+
+function expectPrewarmPosted(worker: MockSearchWorker): void {
+  expect(worker.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+    type: "prewarm",
+    profileId,
+  }));
+}
+
+describe("search index worker client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    MockSearchWorker.instances = [];
+  });
+
+  afterEach(() => {
+    setGlobalWorker(originalWorker);
+  });
+
+  it("retries worker creation after a constructor failure", async () => {
+    let shouldThrow = true;
+    const WorkerConstructor = installWorker(() => {
+      if (shouldThrow) {
+        shouldThrow = false;
+        throw new Error("worker startup failed");
+      }
+      return new MockSearchWorker();
+    });
+    const { prewarmSearchIndex } = await import("./searchIndex");
+
+    await prewarmSearchIndex(profileId);
+    await prewarmSearchIndex(profileId);
+
+    expect(WorkerConstructor).toHaveBeenCalledTimes(2);
+    expect(coreMocks.prewarmSearchIndex).toHaveBeenCalledTimes(1);
+    expect(MockSearchWorker.instances).toHaveLength(1);
+    expectPrewarmPosted(MockSearchWorker.instances[0]);
+  });
+
+  it("retries worker creation after a runtime worker error", async () => {
+    let shouldAutoRespond = false;
+    const WorkerConstructor = installWorker(() => {
+      const worker = new MockSearchWorker(shouldAutoRespond);
+      shouldAutoRespond = true;
+      return worker;
+    });
+    const { prewarmSearchIndex } = await import("./searchIndex");
+
+    const firstPrewarm = prewarmSearchIndex(profileId);
+    MockSearchWorker.instances[0].fail("transient worker error");
+    await expect(firstPrewarm).rejects.toThrow("transient worker error");
+
+    await prewarmSearchIndex(profileId);
+
+    expect(WorkerConstructor).toHaveBeenCalledTimes(2);
+    expect(coreMocks.prewarmSearchIndex).not.toHaveBeenCalled();
+    expect(MockSearchWorker.instances).toHaveLength(2);
+    expect(MockSearchWorker.instances[0].terminate).toHaveBeenCalledTimes(1);
+    expectPrewarmPosted(MockSearchWorker.instances[1]);
+  });
+});

--- a/src/lib/ai/searchIndex.ts
+++ b/src/lib/ai/searchIndex.ts
@@ -26,6 +26,13 @@ let workerInitAttempted = false;
 let requestCounter = 0;
 const pending = new Map<string, { resolve: (value: unknown) => void; reject: (reason: unknown) => void }>();
 
+function resetWorkerAfterFailure(): Worker | null {
+  const failedWorker = worker;
+  worker = null;
+  workerInitAttempted = false;
+  return failedWorker;
+}
+
 function getWorker(): Worker | null {
   if (typeof Worker === "undefined") return null;
   if (worker) return worker;
@@ -49,10 +56,11 @@ function getWorker(): Worker | null {
         handler.reject(new Error(event.message ?? "Search worker error"));
       }
       pending.clear();
-      worker = null;
+      resetWorkerAfterFailure()?.terminate();
     };
     return worker;
   } catch {
+    resetWorkerAfterFailure();
     return null;
   }
 }

--- a/src/lib/ai/searchIndex.ts
+++ b/src/lib/ai/searchIndex.ts
@@ -1,354 +1,138 @@
-import { create, insertMultiple, load as loadOrama, save as saveOrama, search, type AnyOrama, type RawData } from "@orama/orama";
+import type {
+  SearchCandidate,
+  SearchExplorerEntryIdsRequest,
+  SearchExplorerEntryIdsResult,
+  WorkerRequest,
+  WorkerResponse,
+} from "./searchIndexCore";
 import {
-  deleteSearchIndexCache,
-  loadSearchIndexCache,
-  loadSearchIndexSource,
-  saveSearchIndexCache,
-} from "../storage";
-import type { EvidenceTier, StoredReportEntry } from "../../types";
-import type { ExplorerFilters } from "../explorer";
+  clearSearchIndex as clearDirect,
+  prewarmSearchIndex as prewarmDirect,
+  queryCandidateIds as queryCandidateIdsDirect,
+  searchExplorerEntryIds as searchExplorerEntryIdsDirect,
+  searchWithFields as searchWithFieldsDirect,
+  waitForIndex as waitForIndexDirect,
+} from "./searchIndexCore";
 
-interface LightEntry {
-  id: string;
-  category: string;
-  title: string;
-  genes: string;
-  topics: string;
-  conditions: string;
-  rsids: string;
-  evidenceTier: string;
-  sourceNames: string[];
-  significance: string;
-  repute: string;
-  coverage: string;
-  publicationBucket: string;
-  geneValues: string[];
-  tagValues: string[];
-  markers: string;
-  body: string;
-  sortSeverity: number;
-  sortEvidence: number;
-  sortPublications: number;
-  sortAlphabetical: string;
+export type { SearchCandidate };
+
+// ---- Worker client ----
+// All Orama operations run in a dedicated worker to isolate memory from the
+// main thread, preventing iOS Safari from killing the tab on memory spikes.
+// When Worker is unavailable (e.g. test environments) the core runs directly.
+
+let worker: Worker | null = null;
+let workerInitAttempted = false;
+let requestCounter = 0;
+const pending = new Map<string, { resolve: (value: unknown) => void; reject: (reason: unknown) => void }>();
+
+function getWorker(): Worker | null {
+  if (typeof Worker === "undefined") return null;
+  if (worker) return worker;
+  if (workerInitAttempted) return null;
+
+  workerInitAttempted = true;
+  try {
+    worker = new Worker(new URL("../../workers/searchIndex.worker.ts", import.meta.url), { type: "module" });
+    worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const handler = pending.get(event.data.requestId);
+      if (!handler) return;
+      pending.delete(event.data.requestId);
+      if (event.data.type === "error") {
+        handler.reject(new Error(event.data.error));
+      } else {
+        handler.resolve(event.data);
+      }
+    };
+    worker.onerror = (event) => {
+      for (const handler of pending.values()) {
+        handler.reject(new Error(event.message ?? "Search worker error"));
+      }
+      pending.clear();
+      worker = null;
+    };
+    return worker;
+  } catch {
+    return null;
+  }
 }
 
-export interface SearchCandidate {
-  id: string;
-  category: string;
-  evidenceTier: EvidenceTier;
-  genes: string;
-  topics: string;
-  conditions: string;
-  rsids: string;
-  title: string;
-  sortSeverity: number;
-  sortEvidence: number;
-}
-
-interface SearchExplorerEntryIdsRequest {
-  profileId: string;
-  category: StoredReportEntry["category"];
-  filters: ExplorerFilters;
-  offset: number;
-  limit: number;
-}
-
-interface SearchExplorerEntryIdsResult {
-  ids: string[];
-  count: number;
-}
-
-const indexes = new Map<string, AnyOrama>();
-const inFlight = new Map<string, Promise<void>>();
-const SEARCH_INDEX_CACHE_VERSION = 3;
-const SEARCH_INDEX_INSERT_BATCH_SIZE = 500;
-const SEARCH_INDEX_SCHEMA = {
-  id: "string",
-  category: "string",
-  title: "string",
-  genes: "string",
-  topics: "string",
-  conditions: "string",
-  rsids: "string",
-  evidenceTier: "string",
-  sourceNames: "string[]",
-  significance: "string",
-  repute: "string",
-  coverage: "string",
-  publicationBucket: "string",
-  geneValues: "string[]",
-  tagValues: "string[]",
-  markers: "string",
-  body: "string",
-  sortSeverity: "number",
-  sortEvidence: "number",
-  sortPublications: "number",
-  sortAlphabetical: "string",
-} as const;
-const SEARCH_INDEX_FIELD_BOOSTS = {
-  rsids: 8,
-  markers: 7,
-  genes: 6,
-  conditions: 5,
-  title: 4,
-  topics: 3,
-  body: 2,
-} as const;
-const EXPLORER_ARRAY_FILTER_FIELDS: Array<[
-  "evidence" | "significance" | "repute" | "coverage" | "publications" | "gene" | "tag",
-  keyof LightEntry,
-]> = [
-  ["evidence", "evidenceTier"],
-  ["significance", "significance"],
-  ["repute", "repute"],
-  ["coverage", "coverage"],
-  ["publications", "publicationBucket"],
-  ["gene", "geneValues"],
-  ["tag", "tagValues"],
-];
-
-function createSearchIndex(): AnyOrama {
-  return create({
-    schema: SEARCH_INDEX_SCHEMA,
+function sendToWorker<T>(w: Worker, message: WorkerRequest): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    pending.set(message.requestId, {
+      resolve: (value) => resolve(value as T),
+      reject,
+    });
+    w.postMessage(message);
   });
 }
 
-function fullTextSearchParams(term: string) {
-  return {
-    term,
-    mode: "fulltext" as const,
-    exact: false,
-    boost: SEARCH_INDEX_FIELD_BOOSTS,
-  };
-}
-
-function toLightEntry(entry: StoredReportEntry): LightEntry {
-  const markerParts: string[] = [];
-  const rsids: string[] = [];
-  for (const marker of entry.matchedMarkers) {
-    rsids.push(marker.rsid);
-    markerParts.push(marker.rsid);
-    if (marker.gene) markerParts.push(marker.gene);
-    if (marker.genotype) markerParts.push(marker.genotype);
-    if (marker.matchedAllele) markerParts.push(marker.matchedAllele);
-  }
-  const body = [
-    entry.summary.slice(0, 240),
-    entry.detail.slice(0, 360),
-    entry.sourceNotes.join(" ").slice(0, 240),
-    (entry.searchText || "").slice(0, 480),
-  ].filter(Boolean).join(" ");
-
-  return {
-    id: entry.id,
-    category: entry.category,
-    title: entry.title.slice(0, 120),
-    genes: entry.genes.join(" "),
-    topics: entry.topics.join(" "),
-    conditions: entry.conditions.join(" "),
-    rsids: rsids.join(" "),
-    evidenceTier: entry.evidenceTier,
-    sourceNames: entry.sources.map((source) => source.name),
-    significance: entry.normalizedClinicalSignificance ?? "",
-    repute: entry.repute,
-    coverage: entry.coverage,
-    publicationBucket: entry.publicationBucket,
-    geneValues: entry.genes,
-    tagValues: [...entry.topics, ...entry.conditions],
-    markers: markerParts.join(" "),
-    body,
-    sortSeverity: entry.sort.severity,
-    sortEvidence: entry.sort.evidence,
-    sortPublications: entry.sort.publications,
-    sortAlphabetical: entry.sort.alphabetical,
-  };
-}
-
-function toSearchCandidate(doc: LightEntry): SearchCandidate {
-  return {
-    id: doc.id,
-    category: doc.category,
-    evidenceTier: (doc.evidenceTier as EvidenceTier) ?? "supplementary",
-    genes: doc.genes,
-    topics: doc.topics,
-    conditions: doc.conditions,
-    rsids: doc.rsids,
-    title: doc.title,
-    sortSeverity: doc.sortSeverity,
-    sortEvidence: doc.sortEvidence,
-  };
-}
-
-async function searchDocs(index: AnyOrama, terms: string[], limit: number): Promise<Array<{ document: LightEntry }>> {
-  if (terms.length === 0) return [];
-  const query = terms.join(" ").trim();
-  if (!query) return [];
-
-  const result = await search(index, {
-    ...fullTextSearchParams(query),
-    tolerance: 1,
-    limit,
-  });
-
-  return result.hits as unknown as Array<{ document: LightEntry }>;
-}
-
-function explorerWhere(category: StoredReportEntry["category"], filters: ExplorerFilters): Record<string, unknown> {
-  const where: Record<string, unknown> = {
-    category,
-  };
-
-  if (filters.source) where.sourceNames = filters.source;
-  for (const [filterKey, documentField] of EXPLORER_ARRAY_FILTER_FIELDS) {
-    const values = filters[filterKey];
-    if (values.length > 0) where[documentField] = values;
-  }
-
-  return where;
-}
-
-function compareExplorerDocuments(left: LightEntry, right: LightEntry, sort: ExplorerFilters["sort"]): number {
-  switch (sort) {
-    case "alphabetical":
-      return left.sortAlphabetical.localeCompare(right.sortAlphabetical);
-    case "publications":
-      return right.sortPublications - left.sortPublications || left.title.localeCompare(right.title);
-    case "evidence":
-      return right.sortEvidence - left.sortEvidence || right.sortSeverity - left.sortSeverity || left.title.localeCompare(right.title);
-    case "severity":
-    default:
-      return right.sortSeverity - left.sortSeverity || right.sortEvidence - left.sortEvidence || left.title.localeCompare(right.title);
-  }
-}
+// ---- Public API ----
 
 export async function prewarmSearchIndex(profileId: string): Promise<void> {
-  if (indexes.has(profileId)) return;
-  if (inFlight.has(profileId)) return inFlight.get(profileId);
-
-  const job = (async () => {
-    const cached = await loadSearchIndexCache(profileId, SEARCH_INDEX_CACHE_VERSION);
-
-    if (cached) {
-      try {
-        const cachedIndex = createSearchIndex();
-        loadOrama(cachedIndex, cached.rawData as RawData);
-        indexes.set(profileId, cachedIndex);
-        return;
-      } catch {
-        // Cached data can be invalidated by Orama internals; rebuild from stored entries.
-      }
-    }
-
-    const index = createSearchIndex();
-
-    const source = await loadSearchIndexSource(profileId);
-    if (!source) {
-      indexes.set(profileId, index);
-      return;
-    }
-
-    const documents: LightEntry[] = [];
-    const seenIds = new Set<string>();
-    for (const entry of source.entries) {
-      if (!seenIds.has(entry.id)) {
-        seenIds.add(entry.id);
-        documents.push(toLightEntry(entry));
-      }
-    }
-
-    if (documents.length > 0) {
-      await insertMultiple(index, documents, SEARCH_INDEX_INSERT_BATCH_SIZE);
-    }
-
-    await saveSearchIndexCache({
-      profileId,
-      cacheVersion: SEARCH_INDEX_CACHE_VERSION,
-      documentCount: documents.length,
-      rawData: saveOrama(index),
-    });
-
-    indexes.set(profileId, index);
-  })().finally(() => inFlight.delete(profileId));
-
-  inFlight.set(profileId, job);
-  return job;
+  const w = getWorker();
+  if (!w) return prewarmDirect(profileId);
+  const requestId = String(++requestCounter);
+  return sendToWorker(w, { type: "prewarm", requestId, profileId });
 }
 
 export async function queryCandidateIds(profileId: string, terms: string[], limit = 50): Promise<string[]> {
-  const index = indexes.get(profileId);
-  if (!index) return [];
-  const hits = await searchDocs(index, terms, limit);
-  return hits.map((result) => result.document.id);
+  const w = getWorker();
+  if (!w) return queryCandidateIdsDirect(profileId, terms, limit);
+  const requestId = String(++requestCounter);
+  const response = await sendToWorker<{ type: "queryCandidates"; requestId: string; result: string[] }>(
+    w,
+    { type: "queryCandidates", requestId, profileId, terms, limit },
+  );
+  return response.result;
 }
 
-export async function searchWithFields(profileId: string, terms: string[], limit: number): Promise<SearchCandidate[]> {
-  const index = indexes.get(profileId);
-  if (!index) return [];
-  const hits = await searchDocs(index, terms, limit);
-
-  return hits.map((result) => toSearchCandidate(result.document));
+export async function searchWithFields(
+  profileId: string,
+  terms: string[],
+  limit: number,
+): Promise<SearchCandidate[]> {
+  const w = getWorker();
+  if (!w) return searchWithFieldsDirect(profileId, terms, limit);
+  const requestId = String(++requestCounter);
+  const response = await sendToWorker<{ type: "searchWithFields"; requestId: string; result: SearchCandidate[] }>(
+    w,
+    { type: "searchWithFields", requestId, profileId, terms, limit },
+  );
+  return response.result;
 }
 
-export async function searchExplorerEntryIds({
-  profileId,
-  category,
-  filters,
-  offset,
-  limit,
-}: SearchExplorerEntryIdsRequest): Promise<SearchExplorerEntryIdsResult> {
-  const index = indexes.get(profileId);
-  const query = filters.q.trim();
-  if (!index || !query) return { ids: [], count: 0 };
-
-  const searchParams = {
-    ...fullTextSearchParams(query),
-    tolerance: 2,
-    threshold: 0,
-    where: explorerWhere(category, filters),
-  } as const;
-
-  // Orama narrows the text match set; Explorer's selected sort remains authoritative for visible ordering.
-  const preflight = await search(index, {
-    ...searchParams,
-    preflight: true,
-  });
-
-  if (preflight.count === 0) return { ids: [], count: 0 };
-
-  const result = await search(index, {
-    ...searchParams,
-    limit: preflight.count,
-  });
-
-  const hits = (result.hits as unknown as Array<{ document: LightEntry; score: number }>)
-    .filter((hit) => hit.score > 0)
-    .sort((left, right) =>
-      compareExplorerDocuments(left.document, right.document, filters.sort) ||
-      right.score - left.score,
-    );
-
-  return {
-    ids: hits.slice(offset, offset + limit).map((hit) => hit.document.id),
-    count: hits.length,
-  };
+export async function searchExplorerEntryIds(
+  request: SearchExplorerEntryIdsRequest,
+): Promise<SearchExplorerEntryIdsResult> {
+  const w = getWorker();
+  if (!w) return searchExplorerEntryIdsDirect(request);
+  const requestId = String(++requestCounter);
+  const response = await sendToWorker<{ type: "searchExplorer"; requestId: string; result: SearchExplorerEntryIdsResult }>(
+    w,
+    { type: "searchExplorer", requestId, payload: request },
+  );
+  return response.result;
 }
 
 export async function waitForIndex(profileId: string): Promise<void> {
-  if (indexes.has(profileId)) return;
-  return inFlight.get(profileId) ?? prewarmSearchIndex(profileId);
+  const w = getWorker();
+  if (!w) return waitForIndexDirect(profileId);
+  const requestId = String(++requestCounter);
+  return sendToWorker(w, { type: "waitForIndex", requestId, profileId });
 }
 
 export function clearSearchIndex(
   profileId?: string,
   options: { preservePersistentCache?: boolean } = {},
 ): void {
-  if (profileId) {
-    indexes.delete(profileId);
-    inFlight.delete(profileId);
-    if (!options.preservePersistentCache) void deleteSearchIndexCache(profileId);
+  const w = getWorker();
+  if (!w) {
+    clearDirect(profileId, options);
     return;
   }
-  indexes.clear();
-  inFlight.clear();
-  if (!options.preservePersistentCache) void deleteSearchIndexCache();
+  // Fire-and-forget: worker processes messages in order so this clears before
+  // any subsequent prewarm sent in the same tick.
+  const requestId = String(++requestCounter);
+  w.postMessage({ type: "clearIndex", requestId, profileId, options } satisfies WorkerRequest);
 }

--- a/src/lib/ai/searchIndexCore.ts
+++ b/src/lib/ai/searchIndexCore.ts
@@ -1,0 +1,371 @@
+import { create, insertMultiple, load as loadOrama, save as saveOrama, search, type AnyOrama, type RawData } from "@orama/orama";
+import {
+  deleteSearchIndexCache,
+  loadSearchIndexCache,
+  loadSearchIndexSource,
+  saveSearchIndexCache,
+} from "../storage";
+import type { EvidenceTier, StoredReportEntry } from "../../types";
+import type { ExplorerFilters } from "../explorer";
+
+interface LightEntry {
+  id: string;
+  category: string;
+  title: string;
+  genes: string;
+  topics: string;
+  conditions: string;
+  rsids: string;
+  evidenceTier: string;
+  sourceNames: string[];
+  significance: string;
+  repute: string;
+  coverage: string;
+  publicationBucket: string;
+  geneValues: string[];
+  tagValues: string[];
+  markers: string;
+  body: string;
+  sortSeverity: number;
+  sortEvidence: number;
+  sortPublications: number;
+  sortAlphabetical: string;
+}
+
+export interface SearchCandidate {
+  id: string;
+  category: string;
+  evidenceTier: EvidenceTier;
+  genes: string;
+  topics: string;
+  conditions: string;
+  rsids: string;
+  title: string;
+  sortSeverity: number;
+  sortEvidence: number;
+}
+
+export interface SearchExplorerEntryIdsRequest {
+  profileId: string;
+  category: StoredReportEntry["category"];
+  filters: ExplorerFilters;
+  offset: number;
+  limit: number;
+}
+
+export interface SearchExplorerEntryIdsResult {
+  ids: string[];
+  count: number;
+}
+
+export type WorkerRequest =
+  | { type: "prewarm"; requestId: string; profileId: string }
+  | { type: "waitForIndex"; requestId: string; profileId: string }
+  | { type: "searchExplorer"; requestId: string; payload: SearchExplorerEntryIdsRequest }
+  | { type: "searchWithFields"; requestId: string; profileId: string; terms: string[]; limit: number }
+  | { type: "queryCandidates"; requestId: string; profileId: string; terms: string[]; limit: number }
+  | { type: "clearIndex"; requestId: string; profileId?: string; options?: { preservePersistentCache?: boolean } };
+
+export type WorkerResponse =
+  | { type: "prewarm"; requestId: string }
+  | { type: "waitForIndex"; requestId: string }
+  | { type: "searchExplorer"; requestId: string; result: SearchExplorerEntryIdsResult }
+  | { type: "searchWithFields"; requestId: string; result: SearchCandidate[] }
+  | { type: "queryCandidates"; requestId: string; result: string[] }
+  | { type: "clearIndex"; requestId: string }
+  | { type: "error"; requestId: string; error: string };
+
+const indexes = new Map<string, AnyOrama>();
+const inFlight = new Map<string, Promise<void>>();
+const SEARCH_INDEX_CACHE_VERSION = 3;
+const SEARCH_INDEX_INSERT_BATCH_SIZE = 500;
+const SEARCH_INDEX_SCHEMA = {
+  id: "string",
+  category: "string",
+  title: "string",
+  genes: "string",
+  topics: "string",
+  conditions: "string",
+  rsids: "string",
+  evidenceTier: "string",
+  sourceNames: "string[]",
+  significance: "string",
+  repute: "string",
+  coverage: "string",
+  publicationBucket: "string",
+  geneValues: "string[]",
+  tagValues: "string[]",
+  markers: "string",
+  body: "string",
+  sortSeverity: "number",
+  sortEvidence: "number",
+  sortPublications: "number",
+  sortAlphabetical: "string",
+} as const;
+const SEARCH_INDEX_FIELD_BOOSTS = {
+  rsids: 8,
+  markers: 7,
+  genes: 6,
+  conditions: 5,
+  title: 4,
+  topics: 3,
+  body: 2,
+} as const;
+const EXPLORER_ARRAY_FILTER_FIELDS: Array<[
+  "evidence" | "significance" | "repute" | "coverage" | "publications" | "gene" | "tag",
+  keyof LightEntry,
+]> = [
+  ["evidence", "evidenceTier"],
+  ["significance", "significance"],
+  ["repute", "repute"],
+  ["coverage", "coverage"],
+  ["publications", "publicationBucket"],
+  ["gene", "geneValues"],
+  ["tag", "tagValues"],
+];
+
+function createSearchIndex(): AnyOrama {
+  return create({
+    schema: SEARCH_INDEX_SCHEMA,
+  });
+}
+
+function fullTextSearchParams(term: string) {
+  return {
+    term,
+    mode: "fulltext" as const,
+    exact: false,
+    boost: SEARCH_INDEX_FIELD_BOOSTS,
+  };
+}
+
+function toLightEntry(entry: StoredReportEntry): LightEntry {
+  const markerParts: string[] = [];
+  const rsids: string[] = [];
+  for (const marker of entry.matchedMarkers) {
+    rsids.push(marker.rsid);
+    markerParts.push(marker.rsid);
+    if (marker.gene) markerParts.push(marker.gene);
+    if (marker.genotype) markerParts.push(marker.genotype);
+    if (marker.matchedAllele) markerParts.push(marker.matchedAllele);
+  }
+  const body = [
+    entry.summary.slice(0, 240),
+    entry.detail.slice(0, 360),
+    entry.sourceNotes.join(" ").slice(0, 240),
+    (entry.searchText || "").slice(0, 480),
+  ].filter(Boolean).join(" ");
+
+  return {
+    id: entry.id,
+    category: entry.category,
+    title: entry.title.slice(0, 120),
+    genes: entry.genes.join(" "),
+    topics: entry.topics.join(" "),
+    conditions: entry.conditions.join(" "),
+    rsids: rsids.join(" "),
+    evidenceTier: entry.evidenceTier,
+    sourceNames: entry.sources.map((source) => source.name),
+    significance: entry.normalizedClinicalSignificance ?? "",
+    repute: entry.repute,
+    coverage: entry.coverage,
+    publicationBucket: entry.publicationBucket,
+    geneValues: entry.genes,
+    tagValues: [...entry.topics, ...entry.conditions],
+    markers: markerParts.join(" "),
+    body,
+    sortSeverity: entry.sort.severity,
+    sortEvidence: entry.sort.evidence,
+    sortPublications: entry.sort.publications,
+    sortAlphabetical: entry.sort.alphabetical,
+  };
+}
+
+function toSearchCandidate(doc: LightEntry): SearchCandidate {
+  return {
+    id: doc.id,
+    category: doc.category,
+    evidenceTier: (doc.evidenceTier as EvidenceTier) ?? "supplementary",
+    genes: doc.genes,
+    topics: doc.topics,
+    conditions: doc.conditions,
+    rsids: doc.rsids,
+    title: doc.title,
+    sortSeverity: doc.sortSeverity,
+    sortEvidence: doc.sortEvidence,
+  };
+}
+
+async function searchDocs(index: AnyOrama, terms: string[], limit: number): Promise<Array<{ document: LightEntry }>> {
+  if (terms.length === 0) return [];
+  const query = terms.join(" ").trim();
+  if (!query) return [];
+
+  const result = await search(index, {
+    ...fullTextSearchParams(query),
+    tolerance: 1,
+    limit,
+  });
+
+  return result.hits as unknown as Array<{ document: LightEntry }>;
+}
+
+function explorerWhere(category: StoredReportEntry["category"], filters: ExplorerFilters): Record<string, unknown> {
+  const where: Record<string, unknown> = {
+    category,
+  };
+
+  if (filters.source) where.sourceNames = filters.source;
+  for (const [filterKey, documentField] of EXPLORER_ARRAY_FILTER_FIELDS) {
+    const values = filters[filterKey];
+    if (values.length > 0) where[documentField] = values;
+  }
+
+  return where;
+}
+
+function compareExplorerDocuments(left: LightEntry, right: LightEntry, sort: ExplorerFilters["sort"]): number {
+  switch (sort) {
+    case "alphabetical":
+      return left.sortAlphabetical.localeCompare(right.sortAlphabetical);
+    case "publications":
+      return right.sortPublications - left.sortPublications || left.title.localeCompare(right.title);
+    case "evidence":
+      return right.sortEvidence - left.sortEvidence || right.sortSeverity - left.sortSeverity || left.title.localeCompare(right.title);
+    case "severity":
+    default:
+      return right.sortSeverity - left.sortSeverity || right.sortEvidence - left.sortEvidence || left.title.localeCompare(right.title);
+  }
+}
+
+export async function prewarmSearchIndex(profileId: string): Promise<void> {
+  if (indexes.has(profileId)) return;
+  if (inFlight.has(profileId)) return inFlight.get(profileId);
+
+  const job = (async () => {
+    const cached = await loadSearchIndexCache(profileId, SEARCH_INDEX_CACHE_VERSION);
+
+    if (cached) {
+      try {
+        const cachedIndex = createSearchIndex();
+        loadOrama(cachedIndex, cached.rawData as RawData);
+        indexes.set(profileId, cachedIndex);
+        return;
+      } catch {
+        // Cached data can be invalidated by Orama internals; rebuild from stored entries.
+      }
+    }
+
+    const index = createSearchIndex();
+
+    const source = await loadSearchIndexSource(profileId);
+    if (!source) {
+      indexes.set(profileId, index);
+      return;
+    }
+
+    const documents: LightEntry[] = [];
+    const seenIds = new Set<string>();
+    for (const entry of source.entries) {
+      if (!seenIds.has(entry.id)) {
+        seenIds.add(entry.id);
+        documents.push(toLightEntry(entry));
+      }
+    }
+
+    if (documents.length > 0) {
+      await insertMultiple(index, documents, SEARCH_INDEX_INSERT_BATCH_SIZE);
+    }
+
+    await saveSearchIndexCache({
+      profileId,
+      cacheVersion: SEARCH_INDEX_CACHE_VERSION,
+      documentCount: documents.length,
+      rawData: saveOrama(index),
+    });
+
+    indexes.set(profileId, index);
+  })().finally(() => inFlight.delete(profileId));
+
+  inFlight.set(profileId, job);
+  return job;
+}
+
+export async function queryCandidateIds(profileId: string, terms: string[], limit = 50): Promise<string[]> {
+  const index = indexes.get(profileId);
+  if (!index) return [];
+  const hits = await searchDocs(index, terms, limit);
+  return hits.map((result) => result.document.id);
+}
+
+export async function searchWithFields(profileId: string, terms: string[], limit: number): Promise<SearchCandidate[]> {
+  const index = indexes.get(profileId);
+  if (!index) return [];
+  const hits = await searchDocs(index, terms, limit);
+
+  return hits.map((result) => toSearchCandidate(result.document));
+}
+
+export async function searchExplorerEntryIds({
+  profileId,
+  category,
+  filters,
+  offset,
+  limit,
+}: SearchExplorerEntryIdsRequest): Promise<SearchExplorerEntryIdsResult> {
+  const index = indexes.get(profileId);
+  const query = filters.q.trim();
+  if (!index || !query) return { ids: [], count: 0 };
+
+  const searchParams = {
+    ...fullTextSearchParams(query),
+    tolerance: 1,
+    threshold: 0,
+    where: explorerWhere(category, filters),
+  } as const;
+
+  // Orama narrows the text match set; Explorer's selected sort remains authoritative for visible ordering.
+  const preflight = await search(index, {
+    ...searchParams,
+    preflight: true,
+  });
+
+  if (preflight.count === 0) return { ids: [], count: 0 };
+
+  const result = await search(index, {
+    ...searchParams,
+    limit: preflight.count,
+  });
+
+  const hits = (result.hits as unknown as Array<{ document: LightEntry; score: number }>)
+    .filter((hit) => hit.score > 0)
+    .sort((left, right) =>
+      compareExplorerDocuments(left.document, right.document, filters.sort) ||
+      right.score - left.score,
+    );
+
+  return {
+    ids: hits.slice(offset, offset + limit).map((hit) => hit.document.id),
+    count: hits.length,
+  };
+}
+
+export async function waitForIndex(profileId: string): Promise<void> {
+  if (indexes.has(profileId)) return;
+  return inFlight.get(profileId) ?? prewarmSearchIndex(profileId);
+}
+
+export function clearSearchIndex(
+  profileId?: string,
+  options: { preservePersistentCache?: boolean } = {},
+): void {
+  if (profileId) {
+    indexes.delete(profileId);
+    inFlight.delete(profileId);
+    if (!options.preservePersistentCache) void deleteSearchIndexCache(profileId);
+    return;
+  }
+  indexes.clear();
+  inFlight.clear();
+  if (!options.preservePersistentCache) void deleteSearchIndexCache();
+}

--- a/src/lib/ai/searchIndexCore.ts
+++ b/src/lib/ai/searchIndexCore.ts
@@ -1,5 +1,5 @@
-import { create, insertMultiple, search, type AnyOrama } from "@orama/orama";
-import { pluginQPS } from "@orama/plugin-qps";
+import MiniSearch from "minisearch";
+import type { SearchResult } from "minisearch";
 import {
   deleteSearchIndexCache,
   loadSearchIndexCache,
@@ -27,8 +27,8 @@ interface LightEntry {
   tagValues: string[];
   markers: string;
   body: string;
-  // Sort fields are stored with the document but kept outside the schema so
-  // Orama does not build inverted index entries for them, reducing memory.
+  // Sort fields stored with the document but outside the search fields,
+  // so MiniSearch does not build index entries for them.
   sortSeverity: number;
   sortEvidence: number;
   sortPublications: number;
@@ -78,37 +78,17 @@ export type WorkerResponse =
   | { type: "clearIndex"; requestId: string }
   | { type: "error"; requestId: string; error: string };
 
-const indexes = new Map<string, AnyOrama>();
+const indexes = new Map<string, MiniSearch<LightEntry>>();
 const inFlight = new Map<string, Promise<void>>();
 
-// Version 4: switched to LightEntry[] cache format (avoids loadOrama/saveOrama
-// 2× memory spike) and added QPS plugin + removed sort fields from schema.
-const SEARCH_INDEX_CACHE_VERSION = 4;
-const SEARCH_INDEX_INSERT_BATCH_SIZE = 100;
+// Version 5: replaced Orama with MiniSearch and added evidence-tier quality filter.
+const SEARCH_INDEX_CACHE_VERSION = 5;
+const SEARCH_INDEX_INSERT_BATCH_SIZE = 500;
 
-// Only searchable and filterable fields go in the schema. Sort-only fields
-// (sortSeverity, sortEvidence, sortPublications, sortAlphabetical) are
-// inserted as extra document properties — Orama stores them but does not
-// build inverted index entries for them, cutting index memory significantly.
-const SEARCH_INDEX_SCHEMA = {
-  id: "string",
-  category: "string",
-  title: "string",
-  genes: "string",
-  topics: "string",
-  conditions: "string",
-  rsids: "string",
-  evidenceTier: "string",
-  sourceNames: "string[]",
-  significance: "string",
-  repute: "string",
-  coverage: "string",
-  publicationBucket: "string",
-  geneValues: "string[]",
-  tagValues: "string[]",
-  markers: "string",
-  body: "string",
-} as const;
+// Only index entries with meaningful evidence quality. preview/supplementary entries
+// are not surfaced by AI search, so excluding them keeps the index small enough for iOS.
+const INDEXED_EVIDENCE_TIERS = new Set<EvidenceTier>(["high", "moderate", "emerging"]);
+
 const SEARCH_INDEX_FIELD_BOOSTS = {
   rsids: 8,
   markers: 7,
@@ -118,6 +98,7 @@ const SEARCH_INDEX_FIELD_BOOSTS = {
   topics: 3,
   body: 2,
 } as const;
+
 const EXPLORER_ARRAY_FILTER_FIELDS: Array<[
   "evidence" | "significance" | "repute" | "coverage" | "publications" | "gene" | "tag",
   keyof LightEntry,
@@ -131,20 +112,17 @@ const EXPLORER_ARRAY_FILTER_FIELDS: Array<[
   ["tag", "tagValues"],
 ];
 
-function createSearchIndex(): AnyOrama {
-  return create({
-    schema: SEARCH_INDEX_SCHEMA,
-    plugins: [pluginQPS()],
+function createSearchIndex(): MiniSearch<LightEntry> {
+  return new MiniSearch<LightEntry>({
+    idField: "id",
+    fields: ["title", "genes", "topics", "conditions", "rsids", "markers", "body"],
+    storeFields: [
+      "id", "category", "evidenceTier", "genes", "topics", "conditions", "rsids",
+      "title", "sortSeverity", "sortEvidence", "sortPublications", "sortAlphabetical",
+      "significance", "repute", "coverage", "publicationBucket",
+      "geneValues", "tagValues", "sourceNames",
+    ],
   });
-}
-
-function fullTextSearchParams(term: string) {
-  return {
-    term,
-    mode: "fulltext" as const,
-    exact: false,
-    boost: SEARCH_INDEX_FIELD_BOOSTS,
-  };
 }
 
 function toLightEntry(entry: StoredReportEntry): LightEntry {
@@ -189,66 +167,71 @@ function toLightEntry(entry: StoredReportEntry): LightEntry {
   };
 }
 
-function toSearchCandidate(doc: LightEntry): SearchCandidate {
+function toSearchCandidate(result: SearchResult): SearchCandidate {
   return {
-    id: doc.id,
-    category: doc.category,
-    evidenceTier: (doc.evidenceTier as EvidenceTier) ?? "supplementary",
-    genes: doc.genes,
-    topics: doc.topics,
-    conditions: doc.conditions,
-    rsids: doc.rsids,
-    title: doc.title,
-    sortSeverity: doc.sortSeverity,
-    sortEvidence: doc.sortEvidence,
+    id: result.id as string,
+    category: result.category as string,
+    evidenceTier: (result.evidenceTier as EvidenceTier) ?? "supplementary",
+    genes: result.genes as string,
+    topics: result.topics as string,
+    conditions: result.conditions as string,
+    rsids: result.rsids as string,
+    title: result.title as string,
+    sortSeverity: result.sortSeverity as number,
+    sortEvidence: result.sortEvidence as number,
   };
 }
 
-async function insertBatched(index: AnyOrama, documents: LightEntry[]): Promise<void> {
+function insertBatched(index: MiniSearch<LightEntry>, documents: LightEntry[]): void {
   for (let i = 0; i < documents.length; i += SEARCH_INDEX_INSERT_BATCH_SIZE) {
-    await insertMultiple(index, documents.slice(i, i + SEARCH_INDEX_INSERT_BATCH_SIZE));
+    index.addAll(documents.slice(i, i + SEARCH_INDEX_INSERT_BATCH_SIZE));
   }
 }
 
-async function searchDocs(index: AnyOrama, terms: string[], limit: number): Promise<Array<{ document: LightEntry }>> {
+function searchDocs(index: MiniSearch<LightEntry>, terms: string[], limit: number): SearchResult[] {
   if (terms.length === 0) return [];
   const query = terms.join(" ").trim();
   if (!query) return [];
-
-  const result = await search(index, {
-    ...fullTextSearchParams(query),
-    tolerance: 1,
-    limit,
-  });
-
-  return result.hits as unknown as Array<{ document: LightEntry }>;
+  return index.search(query, {
+    boost: SEARCH_INDEX_FIELD_BOOSTS,
+    fuzzy: 0.2,
+    prefix: true,
+    combineWith: "OR",
+  }).slice(0, limit);
 }
 
-function explorerWhere(category: StoredReportEntry["category"], filters: ExplorerFilters): Record<string, unknown> {
-  const where: Record<string, unknown> = {
-    category,
+function explorerFilter(category: StoredReportEntry["category"], filters: ExplorerFilters) {
+  return (result: SearchResult): boolean => {
+    if ((result.category as string) !== category) return false;
+    if (filters.source && !(result.sourceNames as string[]).includes(filters.source)) return false;
+    for (const [filterKey, documentField] of EXPLORER_ARRAY_FILTER_FIELDS) {
+      const values = filters[filterKey];
+      if (values.length === 0) continue;
+      const docValue = result[documentField as string];
+      if (Array.isArray(docValue)) {
+        if (!values.some((v) => (docValue as string[]).includes(v))) return false;
+      } else if (!values.includes(docValue as string)) return false;
+    }
+    return true;
   };
-
-  if (filters.source) where.sourceNames = filters.source;
-  for (const [filterKey, documentField] of EXPLORER_ARRAY_FILTER_FIELDS) {
-    const values = filters[filterKey];
-    if (values.length > 0) where[documentField] = values;
-  }
-
-  return where;
 }
 
-function compareExplorerDocuments(left: LightEntry, right: LightEntry, sort: ExplorerFilters["sort"]): number {
+function compareExplorerDocuments(left: SearchResult, right: SearchResult, sort: ExplorerFilters["sort"]): number {
   switch (sort) {
     case "alphabetical":
-      return left.sortAlphabetical.localeCompare(right.sortAlphabetical);
+      return (left.sortAlphabetical as string).localeCompare(right.sortAlphabetical as string);
     case "publications":
-      return right.sortPublications - left.sortPublications || left.title.localeCompare(right.title);
+      return (right.sortPublications as number) - (left.sortPublications as number)
+        || (left.title as string).localeCompare(right.title as string);
     case "evidence":
-      return right.sortEvidence - left.sortEvidence || right.sortSeverity - left.sortSeverity || left.title.localeCompare(right.title);
+      return (right.sortEvidence as number) - (left.sortEvidence as number)
+        || (right.sortSeverity as number) - (left.sortSeverity as number)
+        || (left.title as string).localeCompare(right.title as string);
     case "severity":
     default:
-      return right.sortSeverity - left.sortSeverity || right.sortEvidence - left.sortEvidence || left.title.localeCompare(right.title);
+      return (right.sortSeverity as number) - (left.sortSeverity as number)
+        || (right.sortEvidence as number) - (left.sortEvidence as number)
+        || (left.title as string).localeCompare(right.title as string);
   }
 }
 
@@ -259,15 +242,12 @@ export async function prewarmSearchIndex(profileId: string): Promise<void> {
   const job = (async () => {
     const index = createSearchIndex();
 
-    // Cache (v4+) stores LightEntry[] directly. This avoids the 2× memory
-    // spike that occurred when saveOrama/loadOrama held both the serialised
-    // JSON blob and the live index structure in memory simultaneously.
     const cached = await loadSearchIndexCache(profileId, SEARCH_INDEX_CACHE_VERSION);
     if (cached) {
       try {
         const documents = cached.rawData as LightEntry[];
         if (Array.isArray(documents) && documents.length > 0) {
-          await insertBatched(index, documents);
+          insertBatched(index, documents);
           indexes.set(profileId, index);
           return;
         }
@@ -282,8 +262,6 @@ export async function prewarmSearchIndex(profileId: string): Promise<void> {
       return;
     }
 
-    // Convert and insert in batches so we never hold a full parallel LightEntry[]
-    // alongside source.entries — only one small batch lives at a time.
     const allDocuments: LightEntry[] = [];
     const seenIds = new Set<string>();
     let batch: LightEntry[] = [];
@@ -291,16 +269,17 @@ export async function prewarmSearchIndex(profileId: string): Promise<void> {
     for (const entry of source.entries) {
       if (seenIds.has(entry.id)) continue;
       seenIds.add(entry.id);
+      if (!INDEXED_EVIDENCE_TIERS.has(entry.evidenceTier)) continue;
       const doc = toLightEntry(entry);
       allDocuments.push(doc);
       batch.push(doc);
       if (batch.length >= SEARCH_INDEX_INSERT_BATCH_SIZE) {
-        await insertMultiple(index, batch);
+        index.addAll(batch);
         batch = [];
       }
     }
     if (batch.length > 0) {
-      await insertMultiple(index, batch);
+      index.addAll(batch);
     }
 
     await saveSearchIndexCache({
@@ -320,16 +299,13 @@ export async function prewarmSearchIndex(profileId: string): Promise<void> {
 export async function queryCandidateIds(profileId: string, terms: string[], limit = 50): Promise<string[]> {
   const index = indexes.get(profileId);
   if (!index) return [];
-  const hits = await searchDocs(index, terms, limit);
-  return hits.map((result) => result.document.id);
+  return searchDocs(index, terms, limit).map((result) => result.id as string);
 }
 
 export async function searchWithFields(profileId: string, terms: string[], limit: number): Promise<SearchCandidate[]> {
   const index = indexes.get(profileId);
   if (!index) return [];
-  const hits = await searchDocs(index, terms, limit);
-
-  return hits.map((result) => toSearchCandidate(result.document));
+  return searchDocs(index, terms, limit).map(toSearchCandidate);
 }
 
 export async function searchExplorerEntryIds({
@@ -343,35 +319,23 @@ export async function searchExplorerEntryIds({
   const query = filters.q.trim();
   if (!index || !query) return { ids: [], count: 0 };
 
-  const searchParams = {
-    ...fullTextSearchParams(query),
-    tolerance: 1,
-    threshold: 0,
-    where: explorerWhere(category, filters),
-  } as const;
-
-  // Orama narrows the text match set; Explorer's selected sort remains authoritative for visible ordering.
-  const preflight = await search(index, {
-    ...searchParams,
-    preflight: true,
-  });
-
-  if (preflight.count === 0) return { ids: [], count: 0 };
-
-  const result = await search(index, {
-    ...searchParams,
-    limit: preflight.count,
-  });
-
-  const hits = (result.hits as unknown as Array<{ document: LightEntry; score: number }>)
+  const hits = index
+    .search(query, {
+      boost: SEARCH_INDEX_FIELD_BOOSTS,
+      fuzzy: 0.2,
+      prefix: true,
+      combineWith: "OR",
+      filter: explorerFilter(category, filters),
+    })
     .filter((hit) => hit.score > 0)
     .sort((left, right) =>
-      compareExplorerDocuments(left.document, right.document, filters.sort) ||
-      right.score - left.score,
+      compareExplorerDocuments(left, right, filters.sort) || right.score - left.score,
     );
 
+  if (hits.length === 0) return { ids: [], count: 0 };
+
   return {
-    ids: hits.slice(offset, offset + limit).map((hit) => hit.document.id),
+    ids: hits.slice(offset, offset + limit).map((hit) => hit.id as string),
     count: hits.length,
   };
 }

--- a/src/lib/ai/searchIndexCore.ts
+++ b/src/lib/ai/searchIndexCore.ts
@@ -6,21 +6,23 @@ import {
   loadSearchIndexSource,
   saveSearchIndexCache,
 } from "../storage";
-import type { EvidenceTier, StoredReportEntry } from "../../types";
+import { rankingQualityMultiplier } from "./ranking";
+import type { EvidenceTier, FindingOutcome, ReputeStatus, StoredReportEntry } from "../../types";
 import type { ExplorerFilters } from "../explorer";
 
 interface LightEntry {
   id: string;
-  category: string;
+  category: StoredReportEntry["category"];
   title: string;
   genes: string;
   topics: string;
   conditions: string;
   rsids: string;
-  evidenceTier: string;
+  evidenceTier: EvidenceTier;
+  outcome: FindingOutcome;
   sourceNames: string[];
   significance: string;
-  repute: string;
+  repute: ReputeStatus;
   coverage: string;
   publicationBucket: string;
   geneValues: string[];
@@ -37,6 +39,7 @@ interface LightEntry {
 
 export interface SearchCandidate {
   id: string;
+  score: number;
   category: string;
   evidenceTier: EvidenceTier;
   genes: string;
@@ -46,6 +49,8 @@ export interface SearchCandidate {
   title: string;
   sortSeverity: number;
   sortEvidence: number;
+  outcome: FindingOutcome;
+  repute: ReputeStatus;
 }
 
 export interface SearchExplorerEntryIdsRequest {
@@ -81,22 +86,22 @@ export type WorkerResponse =
 const indexes = new Map<string, MiniSearch<LightEntry>>();
 const inFlight = new Map<string, Promise<void>>();
 
-// Version 5: replaced Orama with MiniSearch and added evidence-tier quality filter.
-const SEARCH_INDEX_CACHE_VERSION = 5;
+// Version 7: includes supplementary SNPedia context in the local search index.
+const SEARCH_INDEX_CACHE_VERSION = 7;
 const SEARCH_INDEX_INSERT_BATCH_SIZE = 500;
 
-// Only index entries with meaningful evidence quality. preview/supplementary entries
-// are not surfaced by AI search, so excluding them keeps the index small enough for iOS.
-const INDEXED_EVIDENCE_TIERS = new Set<EvidenceTier>(["high", "moderate", "emerging"]);
+// Search should still find contextual SNPedia and preview records. Ranking
+// penalties keep them below stronger evidence when relevance is comparable.
+const INDEXED_EVIDENCE_TIERS = new Set<EvidenceTier>(["high", "moderate", "emerging", "preview", "supplementary"]);
 
 const SEARCH_INDEX_FIELD_BOOSTS = {
-  rsids: 8,
-  markers: 7,
-  genes: 6,
-  conditions: 5,
-  title: 4,
+  rsids: 12,
+  markers: 10,
+  genes: 8,
+  conditions: 6,
+  title: 6,
   topics: 3,
-  body: 2,
+  body: 1,
 } as const;
 
 const EXPLORER_ARRAY_FILTER_FIELDS: Array<[
@@ -119,7 +124,7 @@ function createSearchIndex(): MiniSearch<LightEntry> {
     storeFields: [
       "id", "category", "evidenceTier", "genes", "topics", "conditions", "rsids",
       "title", "sortSeverity", "sortEvidence", "sortPublications", "sortAlphabetical",
-      "significance", "repute", "coverage", "publicationBucket",
+      "outcome", "significance", "repute", "coverage", "publicationBucket",
       "geneValues", "tagValues", "sourceNames",
     ],
   });
@@ -151,6 +156,7 @@ function toLightEntry(entry: StoredReportEntry): LightEntry {
     conditions: entry.conditions.join(" "),
     rsids: rsids.join(" "),
     evidenceTier: entry.evidenceTier,
+    outcome: entry.outcome,
     sourceNames: entry.sources.map((source) => source.name),
     significance: entry.normalizedClinicalSignificance ?? "",
     repute: entry.repute,
@@ -170,6 +176,7 @@ function toLightEntry(entry: StoredReportEntry): LightEntry {
 function toSearchCandidate(result: SearchResult): SearchCandidate {
   return {
     id: result.id as string,
+    score: result.score,
     category: result.category as string,
     evidenceTier: (result.evidenceTier as EvidenceTier) ?? "supplementary",
     genes: result.genes as string,
@@ -179,6 +186,8 @@ function toSearchCandidate(result: SearchResult): SearchCandidate {
     title: result.title as string,
     sortSeverity: result.sortSeverity as number,
     sortEvidence: result.sortEvidence as number,
+    outcome: (result.outcome as FindingOutcome) ?? "informational",
+    repute: (result.repute as ReputeStatus) ?? "not-set",
   };
 }
 
@@ -194,7 +203,8 @@ function searchDocs(index: MiniSearch<LightEntry>, terms: string[], limit: numbe
   if (!query) return [];
   return index.search(query, {
     boost: SEARCH_INDEX_FIELD_BOOSTS,
-    fuzzy: 0.2,
+    fuzzy: (term) => term.length >= 5 ? 0.2 : false,
+    maxFuzzy: 2,
     prefix: true,
     combineWith: "OR",
   }).slice(0, limit);
@@ -233,6 +243,18 @@ function compareExplorerDocuments(left: SearchResult, right: SearchResult, sort:
         || (right.sortEvidence as number) - (left.sortEvidence as number)
         || (left.title as string).localeCompare(right.title as string);
   }
+}
+
+function qualityMultiplier(result: SearchResult): number {
+  return rankingQualityMultiplier({
+    evidenceTier: result.evidenceTier,
+    outcome: result.outcome,
+    repute: result.repute,
+  });
+}
+
+function explorerRelevanceScore(result: SearchResult): number {
+  return result.score * qualityMultiplier(result);
 }
 
 export async function prewarmSearchIndex(profileId: string): Promise<void> {
@@ -322,14 +344,17 @@ export async function searchExplorerEntryIds({
   const hits = index
     .search(query, {
       boost: SEARCH_INDEX_FIELD_BOOSTS,
-      fuzzy: 0.2,
-      prefix: true,
-      combineWith: "OR",
+      fuzzy: (term) => term.length >= 5 ? 0.2 : false,
+      maxFuzzy: 2,
+      prefix: (term) => term.length >= 3,
+      combineWith: "AND",
       filter: explorerFilter(category, filters),
     })
     .filter((hit) => hit.score > 0)
     .sort((left, right) =>
-      compareExplorerDocuments(left, right, filters.sort) || right.score - left.score,
+      explorerRelevanceScore(right) - explorerRelevanceScore(left)
+        || compareExplorerDocuments(left, right, filters.sort)
+        || (left.title as string).localeCompare(right.title as string),
     );
 
   if (hits.length === 0) return { ids: [], count: 0 };

--- a/src/lib/ai/searchIndexCore.ts
+++ b/src/lib/ai/searchIndexCore.ts
@@ -1,4 +1,5 @@
-import { create, insertMultiple, load as loadOrama, save as saveOrama, search, type AnyOrama, type RawData } from "@orama/orama";
+import { create, insertMultiple, search, type AnyOrama } from "@orama/orama";
+import { pluginQPS } from "@orama/plugin-qps";
 import {
   deleteSearchIndexCache,
   loadSearchIndexCache,
@@ -26,6 +27,8 @@ interface LightEntry {
   tagValues: string[];
   markers: string;
   body: string;
+  // Sort fields are stored with the document but kept outside the schema so
+  // Orama does not build inverted index entries for them, reducing memory.
   sortSeverity: number;
   sortEvidence: number;
   sortPublications: number;
@@ -77,8 +80,16 @@ export type WorkerResponse =
 
 const indexes = new Map<string, AnyOrama>();
 const inFlight = new Map<string, Promise<void>>();
-const SEARCH_INDEX_CACHE_VERSION = 3;
-const SEARCH_INDEX_INSERT_BATCH_SIZE = 500;
+
+// Version 4: switched to LightEntry[] cache format (avoids loadOrama/saveOrama
+// 2× memory spike) and added QPS plugin + removed sort fields from schema.
+const SEARCH_INDEX_CACHE_VERSION = 4;
+const SEARCH_INDEX_INSERT_BATCH_SIZE = 100;
+
+// Only searchable and filterable fields go in the schema. Sort-only fields
+// (sortSeverity, sortEvidence, sortPublications, sortAlphabetical) are
+// inserted as extra document properties — Orama stores them but does not
+// build inverted index entries for them, cutting index memory significantly.
 const SEARCH_INDEX_SCHEMA = {
   id: "string",
   category: "string",
@@ -97,10 +108,6 @@ const SEARCH_INDEX_SCHEMA = {
   tagValues: "string[]",
   markers: "string",
   body: "string",
-  sortSeverity: "number",
-  sortEvidence: "number",
-  sortPublications: "number",
-  sortAlphabetical: "string",
 } as const;
 const SEARCH_INDEX_FIELD_BOOSTS = {
   rsids: 8,
@@ -127,6 +134,7 @@ const EXPLORER_ARRAY_FILTER_FIELDS: Array<[
 function createSearchIndex(): AnyOrama {
   return create({
     schema: SEARCH_INDEX_SCHEMA,
+    plugins: [pluginQPS()],
   });
 }
 
@@ -196,6 +204,12 @@ function toSearchCandidate(doc: LightEntry): SearchCandidate {
   };
 }
 
+async function insertBatched(index: AnyOrama, documents: LightEntry[]): Promise<void> {
+  for (let i = 0; i < documents.length; i += SEARCH_INDEX_INSERT_BATCH_SIZE) {
+    await insertMultiple(index, documents.slice(i, i + SEARCH_INDEX_INSERT_BATCH_SIZE));
+  }
+}
+
 async function searchDocs(index: AnyOrama, terms: string[], limit: number): Promise<Array<{ document: LightEntry }>> {
   if (terms.length === 0) return [];
   const query = terms.join(" ").trim();
@@ -243,20 +257,24 @@ export async function prewarmSearchIndex(profileId: string): Promise<void> {
   if (inFlight.has(profileId)) return inFlight.get(profileId);
 
   const job = (async () => {
-    const cached = await loadSearchIndexCache(profileId, SEARCH_INDEX_CACHE_VERSION);
+    const index = createSearchIndex();
 
+    // Cache (v4+) stores LightEntry[] directly. This avoids the 2× memory
+    // spike that occurred when saveOrama/loadOrama held both the serialised
+    // JSON blob and the live index structure in memory simultaneously.
+    const cached = await loadSearchIndexCache(profileId, SEARCH_INDEX_CACHE_VERSION);
     if (cached) {
       try {
-        const cachedIndex = createSearchIndex();
-        loadOrama(cachedIndex, cached.rawData as RawData);
-        indexes.set(profileId, cachedIndex);
-        return;
+        const documents = cached.rawData as LightEntry[];
+        if (Array.isArray(documents) && documents.length > 0) {
+          await insertBatched(index, documents);
+          indexes.set(profileId, index);
+          return;
+        }
       } catch {
-        // Cached data can be invalidated by Orama internals; rebuild from stored entries.
+        // Invalid cache; fall through to rebuild.
       }
     }
-
-    const index = createSearchIndex();
 
     const source = await loadSearchIndexSource(profileId);
     if (!source) {
@@ -264,24 +282,32 @@ export async function prewarmSearchIndex(profileId: string): Promise<void> {
       return;
     }
 
-    const documents: LightEntry[] = [];
+    // Convert and insert in batches so we never hold a full parallel LightEntry[]
+    // alongside source.entries — only one small batch lives at a time.
+    const allDocuments: LightEntry[] = [];
     const seenIds = new Set<string>();
+    let batch: LightEntry[] = [];
+
     for (const entry of source.entries) {
-      if (!seenIds.has(entry.id)) {
-        seenIds.add(entry.id);
-        documents.push(toLightEntry(entry));
+      if (seenIds.has(entry.id)) continue;
+      seenIds.add(entry.id);
+      const doc = toLightEntry(entry);
+      allDocuments.push(doc);
+      batch.push(doc);
+      if (batch.length >= SEARCH_INDEX_INSERT_BATCH_SIZE) {
+        await insertMultiple(index, batch);
+        batch = [];
       }
     }
-
-    if (documents.length > 0) {
-      await insertMultiple(index, documents, SEARCH_INDEX_INSERT_BATCH_SIZE);
+    if (batch.length > 0) {
+      await insertMultiple(index, batch);
     }
 
     await saveSearchIndexCache({
       profileId,
       cacheVersion: SEARCH_INDEX_CACHE_VERSION,
-      documentCount: documents.length,
-      rawData: saveOrama(index),
+      documentCount: allDocuments.length,
+      rawData: allDocuments,
     });
 
     indexes.set(profileId, index);

--- a/src/lib/aiChat.test.ts
+++ b/src/lib/aiChat.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_FILTERS } from "./explorer";
-import { buildChatContext, mergeChatFindings, MAX_CHAT_CONTEXT_FINDINGS } from "./aiChat";
+import {
+  buildChatContext,
+  extractChatFollowUps,
+  mergeChatFindings,
+  MAX_CHAT_CONTEXT_FINDINGS,
+  normalizeChatFollowUps,
+} from "./aiChat";
 import { makeProfileMeta, makeStoredReportEntries } from "../test/fixtures";
 
 describe("buildChatContext", () => {
@@ -102,5 +108,50 @@ describe("mergeChatFindings", () => {
 
     expect(merged).toHaveLength(MAX_CHAT_CONTEXT_FINDINGS);
     expect(merged.filter((finding) => finding.id === "finding-1")).toHaveLength(1);
+  });
+});
+
+describe("extractChatFollowUps", () => {
+  it("extracts hidden follow-up suggestions and strips the marker from assistant content", () => {
+    const result = extractChatFollowUps([
+      "Here is the answer.",
+      '<!-- deana-follow-ups: [{"title":"Explain coverage","body":"What does coverage mean in this report?"},{"title":"Compare findings","body":"Compare the medical and drug findings in this report."}] -->',
+    ].join("\n"));
+
+    expect(result.content).toBe("Here is the answer.");
+    expect(result.followUps).toEqual([
+      { title: "Explain coverage", body: "What does coverage mean in this report?" },
+      { title: "Compare findings", body: "Compare the medical and drug findings in this report." },
+    ]);
+  });
+
+  it("hides malformed follow-up metadata without returning suggestions", () => {
+    const result = extractChatFollowUps("Answer. <!-- deana-follow-ups: not-json -->");
+
+    expect(result.content).toBe("Answer.");
+    expect(result.followUps).toEqual([]);
+  });
+});
+
+describe("normalizeChatFollowUps", () => {
+  it("trims, deduplicates, and caps follow-up suggestions", () => {
+    const result = normalizeChatFollowUps([
+      { title: "  A useful follow-up title that is longer than the button limit  ", body: "  Explain the first finding.  " },
+      { title: "Duplicate", body: "Explain the first finding." },
+      { title: "Second", body: "Explain the second finding." },
+      { title: "Third", body: "Explain the third finding." },
+      { title: "Fourth", body: "Explain the fourth finding." },
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      title: "A useful follow-up title that is longer than",
+      body: "Explain the first finding.",
+    });
+    expect(result.map((followUp) => followUp.title)).toEqual([
+      "A useful follow-up title that is longer than",
+      "Second",
+      "Third",
+    ]);
   });
 });

--- a/src/lib/aiChat.ts
+++ b/src/lib/aiChat.ts
@@ -1,6 +1,5 @@
 import type { ExplorerFilters } from "./explorer.js";
-import type { ExplorerTab, ProfileMeta, ReportEntry, StoredReportEntry } from "../types.js";
-import type { ChatFollowUpSuggestion } from "../types.js";
+import type { ChatFollowUpSuggestion, ExplorerTab, ProfileMeta, ReportEntry, StoredReportEntry } from "../types.js";
 export type { ChatFollowUpSuggestion, ChatSearchPlan } from "../types.js";
 
 export const CHAT_CONTEXT_VERSION = 1;

--- a/src/lib/aiChat.ts
+++ b/src/lib/aiChat.ts
@@ -1,10 +1,15 @@
 import type { ExplorerFilters } from "./explorer.js";
-import type { ExplorerTab, InsightCategory, ProfileMeta, ReportEntry, StoredReportEntry } from "../types.js";
+import type { ExplorerTab, ProfileMeta, ReportEntry, StoredReportEntry } from "../types.js";
+import type { ChatFollowUpSuggestion } from "../types.js";
+export type { ChatFollowUpSuggestion, ChatSearchPlan } from "../types.js";
 
 export const CHAT_CONTEXT_VERSION = 1;
 export const CHAT_CONSENT_VERSION = 1;
 export const MAX_CHAT_CONTEXT_FINDINGS = 18;
 export const MAX_CHAT_SEARCH_RESULTS = 8;
+export const MAX_CHAT_FOLLOW_UPS = 3;
+const MAX_CHAT_FOLLOW_UP_TITLE_LENGTH = 44;
+const MAX_CHAT_FOLLOW_UP_BODY_LENGTH = 220;
 
 export interface ChatConsent {
   accepted: true;
@@ -51,6 +56,54 @@ export interface ChatContextFinding {
 export function formatChatTitle(value: string): string {
   const title = value.replace(/\s+/g, " ").replace(/^["']|["']$/g, "").trim();
   return title.length > 52 ? `${title.slice(0, 49)}...` : title;
+}
+
+function followUpMarkerPattern(): RegExp {
+  return /<!--\s*deana-follow-ups\s*:\s*([\s\S]*?)\s*-->/gi;
+}
+
+function normalizeFollowUpText(value: unknown, maxLength: number): string {
+  return typeof value === "string" ? value.replace(/\s+/g, " ").trim().slice(0, maxLength) : "";
+}
+
+export function normalizeChatFollowUps(value: unknown): ChatFollowUpSuggestion[] {
+  const candidates = Array.isArray(value)
+    ? value
+    : value && typeof value === "object" && "followUps" in value && Array.isArray(value.followUps)
+      ? value.followUps
+      : [];
+  const seenBodies = new Set<string>();
+  const followUps: ChatFollowUpSuggestion[] = [];
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const title = normalizeFollowUpText("title" in candidate ? candidate.title : null, MAX_CHAT_FOLLOW_UP_TITLE_LENGTH);
+    const body = normalizeFollowUpText("body" in candidate ? candidate.body : null, MAX_CHAT_FOLLOW_UP_BODY_LENGTH);
+    const bodyKey = body.toLocaleLowerCase();
+    if (!title || !body || seenBodies.has(bodyKey)) continue;
+    seenBodies.add(bodyKey);
+    followUps.push({ title, body });
+    if (followUps.length >= MAX_CHAT_FOLLOW_UPS) break;
+  }
+
+  return followUps;
+}
+
+export function extractChatFollowUps(content: string): { content: string; followUps: ChatFollowUpSuggestion[] } {
+  const followUps: ChatFollowUpSuggestion[] = [];
+  const strippedContent = content.replace(followUpMarkerPattern(), (_match, payload: string) => {
+    try {
+      followUps.push(...normalizeChatFollowUps(JSON.parse(payload)));
+    } catch {
+      // Invalid model metadata should not leak into the visible chat.
+    }
+    return "";
+  }).trim();
+
+  return {
+    content: strippedContent,
+    followUps: normalizeChatFollowUps(followUps),
+  };
 }
 
 export function buildGatewayProviderOptions(model: string, includeThoughts = false) {
@@ -111,18 +164,6 @@ export interface ChatReportContext {
   };
   selectedFindingId: string | null;
   findings: ChatContextFinding[];
-}
-
-export interface ChatSearchPlan {
-  query: string;
-  categories: InsightCategory[];
-  genes: string[];
-  rsids: string[];
-  topics: string[];
-  conditions: string[];
-  relatedTerms: string[];
-  evidence: ReportEntry["evidenceTier"][];
-  rationale: string;
 }
 
 interface BuildChatContextOptions {

--- a/src/lib/aiRetrieval.test.ts
+++ b/src/lib/aiRetrieval.test.ts
@@ -11,8 +11,7 @@ import {
   streamReportEntries,
 } from "./storage";
 import { makeSavedProfile } from "../test/fixtures";
-import type { ChatSearchPlan } from "./aiChat";
-import type { InsightCategory, StoredReportEntry } from "../types";
+import type { ChatSearchPlan, InsightCategory, StoredReportEntry } from "../types";
 
 vi.mock("./storage", () => ({
   streamReportEntries: vi.fn(),
@@ -143,6 +142,46 @@ describe("searchReportEntriesForChat", () => {
     expect(result.trace.usedFallback).toBe(false);
   });
 
+  it("uses MiniSearch candidate strength instead of rsID plans to choose the result count", async () => {
+    const template = storedEntries().find((entry) => entry.category === "medical")!;
+    const entries = Array.from({ length: 8 }, (_, index) => withSearchText({
+      ...template,
+      id: `medical-factor-rsid-${index}`,
+      title: `Factor V Leiden context ${index}`,
+      summary: "Factor V Leiden clotting context.",
+      genes: ["F5"],
+      matchedMarkers: [{ rsid: "rs6025", genotype: "CT", chromosome: "1", position: 169519049, gene: "F5" }],
+      sort: {
+        ...template.sort,
+        severity: 100 - index,
+      },
+    }));
+    installEntries(entries);
+
+    const result = await searchReportEntriesForChat({
+      profileId: "profile-ai-search",
+      prompt: "Factor V Leiden rs6025",
+      plan: {
+        query: "Factor V Leiden",
+        categories: ["medical"],
+        genes: ["F5"],
+        rsids: ["rs6025"],
+        topics: [],
+        conditions: ["Factor V Leiden"],
+        relatedTerms: [],
+        evidence: [],
+        rationale: "Search a specific marker.",
+      },
+    });
+
+    expect(result.findings.length).toBeGreaterThan(5);
+    expect(result.findings).toHaveLength(8);
+    expect(result.trace.candidateWindowCount).toBe(8);
+    expect(result.trace.sentCount).toBe(8);
+    expect(result.trace.remainingCandidateCount).toBe(0);
+    expect(result.trace.retrievalCursor?.hasMore).toBe(false);
+  });
+
   it("uses AI-planned related terms to search full finding fields", async () => {
     const template = storedEntries()[0];
     const entry: StoredReportEntry = {
@@ -178,7 +217,7 @@ describe("searchReportEntriesForChat", () => {
     expect(result.trace.usedFallback).toBe(false);
   });
 
-  it("deduplicates repeated streamed report entries before building the Orama index", async () => {
+  it("deduplicates repeated streamed report entries before building the MiniSearch index", async () => {
     const template = storedEntries()[0];
     const entry = withSearchText({
       ...template,
@@ -210,7 +249,7 @@ describe("searchReportEntriesForChat", () => {
     expect(result.trace.usedFallback).toBe(false);
   });
 
-  it("restores a cached Orama index without reloading all report entries", async () => {
+  it("restores a cached MiniSearch index without reloading all report entries", async () => {
     const entries = storedEntries();
     installEntries(entries);
 
@@ -300,9 +339,11 @@ describe("searchReportEntriesForChat", () => {
       ...template,
       id: "local-traits-snpedia-rs2003046-c-c",
       category: "traits",
+      subcategory: "snpedia",
       title: "Normal (higher) risk of Male Pattern Baldness",
       summary: "Normal (higher) risk of Male Pattern Baldness.",
       detail: "Discovered by 23andMe based on customer surveys, and considered preliminary research.",
+      evidenceTier: "supplementary",
       conditions: [
         "Discovered by 23andMe based on customer surveys, and considered preliminary research.",
         "Normal (higher) risk of Male Pattern Baldness.",
@@ -310,6 +351,7 @@ describe("searchReportEntriesForChat", () => {
       genes: [],
       topics: ["SNPedia", "Genotype page"],
       matchedMarkers: [{ rsid: "rs2003046", genotype: "CC", chromosome: "7", position: 123, gene: undefined }],
+      sources: [{ id: "snpedia", name: "SNPedia", url: "https://example.com/snpedia" }],
       sourceNotes: ["SNPedia genotype page: Rs2003046(C;C)."],
     });
     const unrelatedEntry = withSearchText({
@@ -348,6 +390,137 @@ describe("searchReportEntriesForChat", () => {
     });
     expect(result.findings.map((finding) => finding.id)).not.toContain(unrelatedEntry.id);
     expect(result.trace.returnedFindings[0].matchedFields).toContain("title");
+  });
+
+  it("keeps relevant supplementary SNPedia context when primary matches crowd the result set", async () => {
+    const template = storedEntries()[0];
+    const primaryMatches = Array.from({ length: 30 }, (_, index) => withSearchText({
+      ...template,
+      id: `local-traits-primary-baldness-${index}`,
+      category: "traits",
+      title: `Male Pattern Baldness primary context ${index}`,
+      summary: "Male Pattern Baldness context.",
+      detail: "Primary evidence context for pattern baldness.",
+      evidenceTier: "high",
+      genes: ["AR"],
+      topics: ["Trait association"],
+      conditions: ["Male Pattern Baldness"],
+      sources: [{ id: "gwas", name: "GWAS Catalog", url: "https://example.com/gwas" }],
+      matchedMarkers: [{ rsid: `rs${300000 + index}`, genotype: "AA", chromosome: "7", position: 100 + index, gene: "AR" }],
+    }));
+    const snpediaContext = withSearchText({
+      ...template,
+      id: "local-traits-snpedia-baldness-context",
+      category: "traits",
+      subcategory: "snpedia",
+      title: "Male Pattern Baldness SNPedia context",
+      summary: "Male Pattern Baldness genotype context.",
+      detail: "Supplementary consumer-facing SNPedia context.",
+      evidenceTier: "supplementary",
+      genes: [],
+      topics: ["SNPedia", "Genotype page"],
+      conditions: ["Male Pattern Baldness"],
+      sources: [{ id: "snpedia", name: "SNPedia", url: "https://example.com/snpedia" }],
+      matchedMarkers: [{ rsid: "rs2003046", genotype: "CC", chromosome: "7", position: 123, gene: undefined }],
+      sourceNotes: ["SNPedia genotype page: Rs2003046(C;C)."],
+    });
+    installEntries([...primaryMatches, snpediaContext]);
+
+    const result = await searchReportEntriesForChat({
+      profileId: "profile-ai-search",
+      prompt: "show me about baldness",
+      plan: {
+        query: "baldness",
+        categories: ["traits"],
+        genes: [],
+        rsids: [],
+        topics: ["pattern baldness"],
+        conditions: ["male pattern baldness"],
+        relatedTerms: ["baldness", "male pattern baldness"],
+        evidence: [],
+        rationale: "Search locally for baldness context.",
+      },
+    });
+
+    expect(result.findings).toHaveLength(18);
+    expect(result.findings.map((finding) => finding.id)).toContain("local-traits-snpedia-baldness-context");
+    expect(result.trace.candidateWindowCount).toBe(31);
+    expect(result.trace.sentCount).toBe(18);
+    expect(result.trace.remainingCandidateCount).toBe(13);
+    expect(result.trace.retrievalCursor?.hasMore).toBe(true);
+
+    const nextResult = await searchReportEntriesForChat({
+      profileId: "profile-ai-search",
+      prompt: result.trace.searchPlan?.query ?? "baldness",
+      plan: result.trace.searchPlan,
+      excludeIds: result.trace.retrievalCursor?.sentFindingIds,
+      offset: result.trace.retrievalCursor?.nextOffset,
+    });
+
+    expect(nextResult.findings.length).toBeGreaterThan(0);
+    expect(nextResult.findings.some((finding) => result.findings.some((previous) => previous.id === finding.id))).toBe(false);
+    expect(nextResult.trace.retrievalCursor?.sentFindingIds.length).toBeGreaterThan(result.trace.retrievalCursor?.sentFindingIds.length ?? 0);
+  });
+
+  it("keeps exact gene and title matches ahead of broad informational matches", async () => {
+    const template = storedEntries()[0];
+    const broadInformational = Array.from({ length: 36 }, (_, index) => withSearchText({
+      ...template,
+      id: `local-medical-apoe-broad-${index}`,
+      category: "medical",
+      title: `General informational note ${index}`,
+      summary: "APOE appears in a broad background note.",
+      detail: "Background evidence mentions APOE without a direct gene finding title.",
+      genes: [],
+      evidenceTier: "emerging",
+      outcome: "informational",
+      repute: "not-set",
+      matchedMarkers: [{ rsid: `rs${100000 + index}`, genotype: "AA", chromosome: "19", position: 100 + index, gene: undefined }],
+      sort: {
+        ...template.sort,
+        severity: 100,
+      },
+    }));
+    const exactMatch = withSearchText({
+      ...template,
+      id: "local-medical-apoe-exact",
+      category: "medical",
+      title: "APOE Alzheimer disease risk context",
+      summary: "APOE genotype context.",
+      genes: ["APOE"],
+      conditions: ["Alzheimer disease"],
+      evidenceTier: "high",
+      outcome: "negative",
+      repute: "bad",
+      matchedMarkers: [{ rsid: "rs429358", genotype: "CT", chromosome: "19", position: 44908684, gene: "APOE" }],
+      sort: {
+        ...template.sort,
+        severity: 1,
+      },
+    });
+    installEntries([...broadInformational, exactMatch]);
+
+    const result = await searchReportEntriesForChat({
+      profileId: "profile-ai-search",
+      prompt: "What does APOE mean for Alzheimer disease?",
+      plan: {
+        query: "APOE Alzheimer",
+        categories: ["medical"],
+        genes: ["APOE"],
+        rsids: [],
+        topics: [],
+        conditions: ["Alzheimer disease"],
+        relatedTerms: ["APOE"],
+        evidence: ["high"],
+        rationale: "Search for APOE Alzheimer context.",
+      },
+    });
+
+    expect(result.findings[0]).toMatchObject({
+      id: "local-medical-apoe-exact",
+      title: "APOE Alzheimer disease risk context",
+    });
+    expect(result.trace.returnedFindings[0].matchedFields).toEqual(expect.arrayContaining(["conditions", "genes", "title"]));
   });
 
   it("does not send unrelated findings when the saved report has no matches", async () => {

--- a/src/lib/aiRetrieval.ts
+++ b/src/lib/aiRetrieval.ts
@@ -34,6 +34,20 @@ interface ChatRetrievalRequest {
   offset?: number;
 }
 
+interface RankedChatEntry {
+  entry: StoredReportEntry;
+  score: number;
+  matchedFields: string[];
+}
+
+interface EntrySearchField {
+  field: string;
+  text: string;
+  weight: number;
+  exactTokens: Set<string>;
+  fuzzyTokens: string[];
+}
+
 function normalize(value: string): string {
   return value.trim().toLowerCase();
 }
@@ -42,9 +56,8 @@ function hasAnyNeedle(haystack: string, needles: string[]): boolean {
   return needles.some((needle) => needle && haystack.includes(needle));
 }
 
-function matchedValues(values: string[], needles: string[]): string[] {
-  const normalizedValues = new Set(values.map(normalize).filter(Boolean));
-  return needles.filter((needle) => normalizedValues.has(needle));
+function matchedSetValues(values: Set<string>, needles: string[]): string[] {
+  return needles.filter((needle) => values.has(needle));
 }
 
 function uniqueValues(values: string[]): string[] {
@@ -84,7 +97,15 @@ function searchTerms(prompt: string, plan: ChatSearchPlan): string[] {
   ]).slice(0, 48);
 }
 
-function entryFieldText(entry: StoredReportEntry): Array<{ field: string; text: string; weight: number }> {
+function exactFieldTokens(text: string): Set<string> {
+  return new Set(text.split(/[^a-z0-9]+/).filter(Boolean));
+}
+
+function fuzzyFieldTokens(text: string): string[] {
+  return text.split(/[^a-z0-9]+/).filter((token) => token.length >= 4);
+}
+
+function entryFieldText(entry: StoredReportEntry): EntrySearchField[] {
   return [
     { field: "title", text: entry.title, weight: 50 },
     { field: "summary", text: entry.summary, weight: 40 },
@@ -118,29 +139,43 @@ function entryFieldText(entry: StoredReportEntry): Array<{ field: string; text: 
     { field: "frequencyNote", text: entry.frequencyNote ?? "", weight: 20 },
     { field: "sourceGenotype", text: [entry.sourceGenotype, entry.sourcePageKey, entry.sourcePageUrl].join(" "), weight: 28 },
     { field: "classification", text: [entry.entryKind, entry.category, entry.subcategory, entry.evidenceTier, entry.repute, entry.coverage, entry.tone, entry.outcome].join(" "), weight: 18 },
-  ].map((field) => ({ ...field, text: normalize(field.text) }));
+  ].map((field) => {
+    const text = normalize(field.text);
+    return {
+      ...field,
+      text,
+      exactTokens: exactFieldTokens(text),
+      fuzzyTokens: fuzzyFieldTokens(text),
+    };
+  });
 }
 
-function fuzzyFieldMatch(text: string, term: string): boolean {
+function fuzzyFieldMatch(tokens: string[], term: string): boolean {
   if (term.length < 4) return false;
-  return text
-    .split(/[^a-z0-9]+/)
-    .filter((token) => token.length >= 4)
-    .some((token) => token.includes(term));
+  return tokens.some((token) => token.includes(term));
 }
 
-function fieldIncludesTerm(text: string, term: string): boolean {
+function fieldIncludesTerm(field: EntrySearchField, term: string): boolean {
   if (term.length <= 3) {
-    return text.split(/[^a-z0-9]+/).filter(Boolean).includes(term);
+    return field.exactTokens.has(term);
   }
 
-  return text.includes(term);
+  return field.text.includes(term);
+}
+
+function compareRankedChatEntries(left: RankedChatEntry, right: RankedChatEntry): number {
+  return right.score - left.score
+    || right.entry.sort.severity - left.entry.sort.severity
+    || left.entry.title.localeCompare(right.entry.title);
 }
 
 function scoreEntry(entry: StoredReportEntry, prompt: string, plan: ChatSearchPlan, terms: string[]): { score: number; matchedFields: string[] } {
   const searchText = entry.searchText || "";
   let score = 0;
   const matchedFields = new Set<string>();
+  const normalizedGenes = new Set(entry.genes.map(normalize).filter(Boolean));
+  const normalizedTopics = new Set(entry.topics.map(normalize).filter(Boolean));
+  const normalizedConditions = new Set(entry.conditions.map(normalize).filter(Boolean));
 
   if (plan.query && matchesEntryFilters(entry, { ...DEFAULT_FILTERS, q: plan.query }, entry.category)) {
     score += 42;
@@ -152,19 +187,19 @@ function scoreEntry(entry: StoredReportEntry, prompt: string, plan: ChatSearchPl
     matchedFields.add("markers");
   }
 
-  const geneMatches = matchedValues(entry.genes, plan.genes);
+  const geneMatches = matchedSetValues(normalizedGenes, plan.genes);
   if (geneMatches.length > 0) {
     score += geneMatches.length * RANKING_WEIGHTS.gene;
     matchedFields.add("genes");
   }
 
-  const topicMatches = matchedValues(entry.topics, plan.topics);
+  const topicMatches = matchedSetValues(normalizedTopics, plan.topics);
   if (topicMatches.length > 0) {
     score += topicMatches.length * RANKING_WEIGHTS.topic;
     matchedFields.add("topics");
   }
 
-  const conditionMatches = matchedValues(entry.conditions, plan.conditions);
+  const conditionMatches = matchedSetValues(normalizedConditions, plan.conditions);
   if (conditionMatches.length > 0) {
     score += conditionMatches.length * RANKING_WEIGHTS.condition;
     matchedFields.add("conditions");
@@ -173,15 +208,15 @@ function scoreEntry(entry: StoredReportEntry, prompt: string, plan: ChatSearchPl
   if (plan.evidence.includes(entry.evidenceTier)) score += RANKING_WEIGHTS.evidenceTier;
   if (plan.query && entry.title.toLowerCase().includes(plan.query.toLowerCase())) score += RANKING_WEIGHTS.titleQuery;
 
-  for (const { field, text, weight } of entryFieldText(entry)) {
+  for (const fieldSearch of entryFieldText(entry)) {
     for (const term of terms) {
       if (!term) continue;
-      if (fieldIncludesTerm(text, term)) {
-        score += weight;
-        matchedFields.add(field);
-      } else if (fuzzyFieldMatch(text, term)) {
-        score += Math.max(6, weight / 5);
-        matchedFields.add(field);
+      if (fieldIncludesTerm(fieldSearch, term)) {
+        score += fieldSearch.weight;
+        matchedFields.add(fieldSearch.field);
+      } else if (fuzzyFieldMatch(fieldSearch.fuzzyTokens, term)) {
+        score += Math.max(6, fieldSearch.weight / 5);
+        matchedFields.add(fieldSearch.field);
       }
     }
   }
@@ -249,9 +284,9 @@ function uniqueIds(values: string[]): string[] {
 }
 
 function selectRankedEntries(
-  ranked: Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }>,
+  ranked: RankedChatEntry[],
   limit: number,
-): Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }> {
+): RankedChatEntry[] {
   if (limit <= 0) return [];
 
   const selected = ranked.slice(0, limit);
@@ -278,11 +313,7 @@ function selectRankedEntries(
     supplementalCount += 1;
   }
 
-  return selected.sort((left, right) =>
-    right.score - left.score ||
-    right.entry.sort.severity - left.entry.sort.severity ||
-    left.entry.title.localeCompare(right.entry.title),
-  );
+  return selected.sort(compareRankedChatEntries);
 }
 
 function preScoreCandidate(candidate: SearchCandidate, plan: ChatSearchPlan): number {
@@ -320,7 +351,7 @@ export async function searchReportEntriesForChat({
   const effectivePlan = compactPlan(plan ?? fallbackPlan(prompt));
   const categories = ALL_CATEGORIES;
   const terms = searchTerms(prompt, effectivePlan);
-  const ranked: Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }> = [];
+  const ranked: RankedChatEntry[] = [];
   const seen = new Set<string>();
   const excludedIds = new Set(excludeIds);
 
@@ -364,11 +395,7 @@ export async function searchReportEntriesForChat({
     fallbackScannedAt = performance.now();
   }
 
-  ranked.sort((left, right) =>
-    right.score - left.score ||
-    right.entry.sort.severity - left.entry.sort.severity ||
-    left.entry.title.localeCompare(right.entry.title),
-  );
+  ranked.sort(compareRankedChatEntries);
 
   const effectiveLimit = resolveCandidateGuidedLimit(candidates, ranked.length, limit);
   const selectedRankedEntries = selectRankedEntries(ranked, effectiveLimit);

--- a/src/lib/aiRetrieval.ts
+++ b/src/lib/aiRetrieval.ts
@@ -1,16 +1,37 @@
 import { DEFAULT_FILTERS, matchesEntryFilters } from "./explorer";
-import { findingToChatContext, type ChatContextFinding, type ChatSearchPlan } from "./aiChat";
+import { findingToChatContext, MAX_CHAT_CONTEXT_FINDINGS, type ChatContextFinding } from "./aiChat";
 import { searchWithFields, waitForIndex, type SearchCandidate } from "./ai/searchIndex";
+import { rankingQualityMultiplier } from "./ai/ranking";
 import { loadReportEntriesByIds, streamReportEntries } from "./storage";
-import type { ChatRetrievalTrace, InsightCategory, StoredReportEntry } from "../types";
+import type { ChatRetrievalTrace, ChatSearchPlan, InsightCategory, StoredReportEntry } from "../types";
 
 const ALL_CATEGORIES: InsightCategory[] = ["medical", "traits", "drug"];
+const MIN_CHAT_SEARCH_FINDINGS = 5;
+const INDEX_CANDIDATE_LIMIT = 180;
+const SUPPLEMENTAL_CONTEXT_LIMIT = 2;
+const RANKING_WEIGHTS = {
+  rsid: 90,
+  gene: 70,
+  topic: 28,
+  condition: 28,
+  evidenceTier: 12,
+  titleQuery: 25,
+} as const;
 
 export interface ChatRetrievalResult {
   plan: ChatSearchPlan;
   findings: ChatContextFinding[];
   resultCount: number;
   trace: ChatRetrievalTrace;
+}
+
+interface ChatRetrievalRequest {
+  profileId: string;
+  prompt: string;
+  plan?: ChatSearchPlan;
+  limit?: number;
+  excludeIds?: string[];
+  offset?: number;
 }
 
 function normalize(value: string): string {
@@ -127,30 +148,30 @@ function scoreEntry(entry: StoredReportEntry, prompt: string, plan: ChatSearchPl
   }
 
   if (hasAnyNeedle(searchText, plan.rsids)) {
-    score += 90;
+    score += RANKING_WEIGHTS.rsid;
     matchedFields.add("markers");
   }
 
   const geneMatches = matchedValues(entry.genes, plan.genes);
   if (geneMatches.length > 0) {
-    score += geneMatches.length * 70;
+    score += geneMatches.length * RANKING_WEIGHTS.gene;
     matchedFields.add("genes");
   }
 
   const topicMatches = matchedValues(entry.topics, plan.topics);
   if (topicMatches.length > 0) {
-    score += topicMatches.length * 28;
+    score += topicMatches.length * RANKING_WEIGHTS.topic;
     matchedFields.add("topics");
   }
 
   const conditionMatches = matchedValues(entry.conditions, plan.conditions);
   if (conditionMatches.length > 0) {
-    score += conditionMatches.length * 28;
+    score += conditionMatches.length * RANKING_WEIGHTS.condition;
     matchedFields.add("conditions");
   }
 
-  if (plan.evidence.includes(entry.evidenceTier)) score += 12;
-  if (plan.query && entry.title.toLowerCase().includes(plan.query.toLowerCase())) score += 25;
+  if (plan.evidence.includes(entry.evidenceTier)) score += RANKING_WEIGHTS.evidenceTier;
+  if (plan.query && entry.title.toLowerCase().includes(plan.query.toLowerCase())) score += RANKING_WEIGHTS.titleQuery;
 
   for (const { field, text, weight } of entryFieldText(entry)) {
     for (const term of terms) {
@@ -172,7 +193,9 @@ function scoreEntry(entry: StoredReportEntry, prompt: string, plan: ChatSearchPl
   }
 
   return {
-    score: score + Math.min(entry.sort.severity, 100) / 100 + Math.min(entry.sort.evidence, 100) / 200,
+    score: (score * rankingQualityMultiplier(entry))
+      + Math.min(entry.sort.severity, 100) / 100
+      + Math.min(entry.sort.evidence, 100) / 200,
     matchedFields: Array.from(matchedFields).sort(),
   };
 }
@@ -199,11 +222,67 @@ function fallbackPlan(prompt: string): ChatSearchPlan {
   };
 }
 
-function resolveLimit(plan: ChatSearchPlan): number {
-  if (plan.rsids.length > 0) return 5;
-  if (plan.genes.length > 0) return 10;
-  if (plan.conditions.length + plan.topics.length > 3) return 15;
-  return 12;
+function isSupplementalContext(entry: StoredReportEntry): boolean {
+  return entry.evidenceTier === "supplementary" || entry.subcategory === "snpedia";
+}
+
+function resolveCandidateGuidedLimit(candidates: SearchCandidate[], rankedCount: number, explicitLimit?: number): number {
+  const maxLimit = Math.min(MAX_CHAT_CONTEXT_FINDINGS, rankedCount);
+  if (explicitLimit !== undefined) return Math.min(explicitLimit, maxLimit);
+  if (maxLimit <= MIN_CHAT_SEARCH_FINDINGS) return maxLimit;
+
+  const topScore = candidates[0]?.score ?? 0;
+  if (topScore <= 0) return Math.min(12, maxLimit);
+
+  const relevantCandidateCount = candidates
+    .slice(0, MAX_CHAT_CONTEXT_FINDINGS)
+    .filter((candidate) => candidate.score >= topScore * 0.35).length;
+
+  return Math.min(
+    maxLimit,
+    Math.max(MIN_CHAT_SEARCH_FINDINGS, relevantCandidateCount),
+  );
+}
+
+function uniqueIds(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function selectRankedEntries(
+  ranked: Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }>,
+  limit: number,
+): Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }> {
+  if (limit <= 0) return [];
+
+  const selected = ranked.slice(0, limit);
+  const selectedIds = new Set(selected.map(({ entry }) => entry.id));
+  const supplementalTarget = Math.min(SUPPLEMENTAL_CONTEXT_LIMIT, Math.max(1, Math.floor(limit / 6)));
+  let supplementalCount = selected.filter(({ entry }) => isSupplementalContext(entry)).length;
+
+  for (const supplemental of ranked) {
+    if (supplementalCount >= supplementalTarget) break;
+    if (!isSupplementalContext(supplemental.entry) || selectedIds.has(supplemental.entry.id)) continue;
+
+    let replaceIndex = -1;
+    for (let index = selected.length - 1; index >= 0; index -= 1) {
+      if (!isSupplementalContext(selected[index].entry)) {
+        replaceIndex = index;
+        break;
+      }
+    }
+    if (replaceIndex === -1) break;
+
+    selectedIds.delete(selected[replaceIndex].entry.id);
+    selected[replaceIndex] = supplemental;
+    selectedIds.add(supplemental.entry.id);
+    supplementalCount += 1;
+  }
+
+  return selected.sort((left, right) =>
+    right.score - left.score ||
+    right.entry.sort.severity - left.entry.sort.severity ||
+    left.entry.title.localeCompare(right.entry.title),
+  );
 }
 
 function preScoreCandidate(candidate: SearchCandidate, plan: ChatSearchPlan): number {
@@ -214,18 +293,20 @@ function preScoreCandidate(candidate: SearchCandidate, plan: ChatSearchPlan): nu
   const normTitle = candidate.title.toLowerCase();
   let score = 0;
 
-  if (plan.rsids.some((rsid) => normRsids.includes(rsid))) score += 90;
+  if (plan.rsids.some((rsid) => normRsids.includes(rsid))) score += RANKING_WEIGHTS.rsid;
 
   const geneTokens = new Set(normGenes.split(/\s+/).filter(Boolean));
-  score += plan.genes.filter((g) => geneTokens.has(g)).length * 70;
+  score += plan.genes.filter((g) => geneTokens.has(g)).length * RANKING_WEIGHTS.gene;
 
-  score += plan.topics.filter((t) => normTopics.includes(t)).length * 28;
-  score += plan.conditions.filter((c) => normConditions.includes(c)).length * 28;
+  score += plan.topics.filter((t) => normTopics.includes(t)).length * RANKING_WEIGHTS.topic;
+  score += plan.conditions.filter((c) => normConditions.includes(c)).length * RANKING_WEIGHTS.condition;
 
-  if (plan.evidence.includes(candidate.evidenceTier)) score += 12;
-  if (plan.query && normTitle.includes(plan.query.toLowerCase())) score += 25;
+  if (plan.evidence.includes(candidate.evidenceTier)) score += RANKING_WEIGHTS.evidenceTier;
+  if (plan.query && normTitle.includes(plan.query.toLowerCase())) score += RANKING_WEIGHTS.titleQuery;
 
-  return score + Math.min(candidate.sortSeverity, 100) / 100 + Math.min(candidate.sortEvidence, 100) / 200;
+  return (score * rankingQualityMultiplier(candidate))
+    + Math.min(candidate.sortSeverity, 100) / 100
+    + Math.min(candidate.sortEvidence, 100) / 200;
 }
 
 export async function searchReportEntriesForChat({
@@ -233,28 +314,25 @@ export async function searchReportEntriesForChat({
   prompt,
   plan,
   limit,
-}: {
-  profileId: string;
-  prompt: string;
-  plan?: ChatSearchPlan;
-  limit?: number;
-}): Promise<ChatRetrievalResult> {
+  excludeIds = [],
+  offset = 0,
+}: ChatRetrievalRequest): Promise<ChatRetrievalResult> {
   const effectivePlan = compactPlan(plan ?? fallbackPlan(prompt));
   const categories = ALL_CATEGORIES;
   const terms = searchTerms(prompt, effectivePlan);
-  const effectiveLimit = limit ?? resolveLimit(effectivePlan);
   const ranked: Array<{ entry: StoredReportEntry; score: number; matchedFields: string[] }> = [];
   const seen = new Set<string>();
+  const excludedIds = new Set(excludeIds);
 
   const startedAt = performance.now();
   await waitForIndex(profileId);
   const indexReadyAt = performance.now();
 
-  const indexCandidateLimit = Math.max(60, effectiveLimit * 8);
-  const candidates = await searchWithFields(profileId, terms, indexCandidateLimit);
+  const candidates = await searchWithFields(profileId, terms, INDEX_CANDIDATE_LIMIT);
   const indexSearchedAt = performance.now();
 
   const rankEntry = (entry: StoredReportEntry) => {
+    if (excludedIds.has(entry.id)) return;
     if (seen.has(entry.id)) return;
     seen.add(entry.id);
     const { score, matchedFields } = scoreEntry(entry, prompt, effectivePlan, terms);
@@ -263,14 +341,13 @@ export async function searchReportEntriesForChat({
 
   // Pre-score from stored index fields to identify the most relevant candidates,
   // then load full entries from IDB only for those — avoiding large batch reads.
-  const topN = Math.max(15, effectiveLimit * 3);
-  const topIds = candidates
+  const candidateIds = candidates
     .map((c, i) => ({ id: c.id, score: preScoreCandidate(c, effectivePlan), order: i }))
     .sort((a, b) => b.score - a.score || a.order - b.order)
-    .slice(0, topN)
-    .map((c) => c.id);
+    .map((c) => c.id)
+    .filter((id) => !excludedIds.has(id));
 
-  const indexedEntries = await loadReportEntriesByIds(profileId, topIds);
+  const indexedEntries = await loadReportEntriesByIds(profileId, candidateIds);
   const idbReadAt = performance.now();
   for (const entry of indexedEntries) {
     rankEntry(entry);
@@ -293,9 +370,14 @@ export async function searchReportEntriesForChat({
     left.entry.title.localeCompare(right.entry.title),
   );
 
-  const selectedRanked = ranked.slice(0, effectiveLimit);
-  const selected = selectedRanked.map(({ entry }) => findingToChatContext(entry));
+  const effectiveLimit = resolveCandidateGuidedLimit(candidates, ranked.length, limit);
+  const selectedRankedEntries = selectRankedEntries(ranked, effectiveLimit);
+  const selectedFindings = selectedRankedEntries.map(({ entry }) => findingToChatContext(entry));
   const completedAt = performance.now();
+  const selectedIds = selectedRankedEntries.map(({ entry }) => entry.id);
+  const sentFindingIds = uniqueIds([...excludeIds, ...selectedIds]);
+  const remainingCandidateCount = Math.max(0, candidates.length - sentFindingIds.length);
+  const hasMore = remainingCandidateCount > 0 && selectedFindings.length > 0;
   const timingMs = {
     total: Math.round(completedAt - startedAt),
     indexWait: Math.round(indexReadyAt - startedAt),
@@ -307,15 +389,18 @@ export async function searchReportEntriesForChat({
 
   return {
     plan: effectivePlan,
-    findings: selected,
-    resultCount: selected.length,
+    findings: selectedFindings,
+    resultCount: selectedFindings.length,
     trace: {
       searchedAt: new Date().toISOString(),
       scannedCategories: categories,
       searchedTerms: terms,
       relatedTerms: effectivePlan.relatedTerms,
-      resultCount: selected.length,
-      returnedFindings: selectedRanked.map(({ entry, matchedFields }) => ({
+      resultCount: selectedFindings.length,
+      sentCount: selectedFindings.length,
+      candidateWindowCount: candidates.length,
+      remainingCandidateCount,
+      returnedFindings: selectedRankedEntries.map(({ entry, matchedFields }) => ({
         id: entry.id,
         title: entry.title,
         category: entry.category,
@@ -324,6 +409,12 @@ export async function searchReportEntriesForChat({
         sourceNames: entry.sources.map((source) => source.name).slice(0, 5),
       })),
       rationale: effectivePlan.rationale,
+      searchPlan: effectivePlan,
+      retrievalCursor: {
+        hasMore,
+        nextOffset: offset + selectedFindings.length,
+        sentFindingIds,
+      },
       indexCandidateCount: candidates.length,
       usedFallback,
       timingMs,

--- a/src/lib/explorerSearch.test.ts
+++ b/src/lib/explorerSearch.test.ts
@@ -109,7 +109,7 @@ describe("loadExplorerPage", () => {
     expect(loadSearchIndexSource).not.toHaveBeenCalled();
   });
 
-  it("uses Orama tolerance for explorer typo search", async () => {
+  it("uses MiniSearch tolerance for explorer typo search", async () => {
     const template = storedEntries()[0];
     const alzheimer = withSearchText({
       ...template,
@@ -133,7 +133,7 @@ describe("loadExplorerPage", () => {
     expect(page.hasMore).toBe(false);
   });
 
-  it("loads non-visible Orama matches from IndexedDB by returned finding IDs", async () => {
+  it("loads non-visible MiniSearch matches from IndexedDB by returned finding IDs", async () => {
     const template = storedEntries()[0];
     const target = withSearchText({
       ...template,
@@ -216,7 +216,149 @@ describe("loadExplorerPage", () => {
     expect(page.entries.map((entry) => entry.id)).toEqual(["medical-factor-v-search"]);
   });
 
-  it("returns stable Orama pages with load more cursors", async () => {
+  it("ranks stronger textual matches above higher-severity body-only matches", async () => {
+    const template = storedEntries()[0];
+    const titleMatch = withSearchText({
+      ...template,
+      id: "medical-lactose-title-match",
+      category: "medical",
+      title: "Lactose intolerance response",
+      summary: "Genotype context for lactose digestion.",
+      sort: {
+        ...template.sort,
+        severity: 1,
+      },
+    });
+    const bodyOnlyMatch = withSearchText({
+      ...template,
+      id: "medical-lactose-body-match",
+      category: "medical",
+      title: "Digestive note",
+      summary: "This lower-priority body copy mentions lactose intolerance in passing.",
+      sort: {
+        ...template.sort,
+        severity: 100,
+      },
+    });
+    installEntries([bodyOnlyMatch, titleMatch]);
+
+    const page = await loadExplorerPage({
+      profileId: "profile-explorer-search",
+      category: "medical",
+      filters: { ...DEFAULT_FILTERS, q: "lactose intolerance" },
+    });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual([
+      "medical-lactose-title-match",
+      "medical-lactose-body-match",
+    ]);
+  });
+
+  it("does not rank partial multi-term matches ahead of full matches", async () => {
+    const template = storedEntries()[0];
+    const fullMatch = withSearchText({
+      ...template,
+      id: "medical-factor-v-full-match",
+      category: "medical",
+      title: "Factor V Leiden clotting risk",
+      summary: "Factor V Leiden thrombophilia context.",
+      genes: ["F5"],
+      matchedMarkers: [{ rsid: "rs6025", genotype: "CT", chromosome: "1", position: 169519049, gene: "F5" }],
+    });
+    const partialMatch = withSearchText({
+      ...template,
+      id: "medical-factor-partial-match",
+      category: "medical",
+      title: "Factor unrelated note",
+      summary: "Mentions factor but not the requested condition.",
+      sort: {
+        ...template.sort,
+        severity: 100,
+      },
+    });
+    installEntries([partialMatch, fullMatch]);
+
+    const page = await loadExplorerPage({
+      profileId: "profile-explorer-search",
+      category: "medical",
+      filters: { ...DEFAULT_FILTERS, q: "factor leiden" },
+    });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual(["medical-factor-v-full-match"]);
+  });
+
+  it("prefers positive and negative findings over informational findings when relevance is close", async () => {
+    const template = storedEntries()[0];
+    const informational = withSearchText({
+      ...template,
+      id: "medical-shared-informational",
+      category: "medical",
+      title: "Shared nutrigenomics match",
+      summary: "Shared nutrigenomics match.",
+      evidenceTier: "high",
+      outcome: "informational",
+      repute: "not-set",
+      sort: {
+        ...template.sort,
+        severity: 100,
+      },
+    });
+    const negative = withSearchText({
+      ...template,
+      id: "medical-shared-negative",
+      category: "medical",
+      title: "Shared nutrigenomics match",
+      summary: "Shared nutrigenomics match.",
+      evidenceTier: "high",
+      outcome: "negative",
+      repute: "bad",
+      sort: {
+        ...template.sort,
+        severity: 1,
+      },
+    });
+    installEntries([informational, negative]);
+
+    const page = await loadExplorerPage({
+      profileId: "profile-explorer-search",
+      category: "medical",
+      filters: { ...DEFAULT_FILTERS, q: "shared nutrigenomics" },
+    });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual([
+      "medical-shared-negative",
+      "medical-shared-informational",
+    ]);
+  });
+
+  it("returns supplementary SNPedia context from MiniSearch results", async () => {
+    const template = storedEntries()[0];
+    const snpedia = withSearchText({
+      ...template,
+      id: "local-traits-snpedia-baldness-context",
+      category: "traits",
+      subcategory: "snpedia",
+      title: "Normal higher risk of Male Pattern Baldness",
+      summary: "SNPedia genotype context for male pattern baldness.",
+      detail: "Supplementary consumer-facing SNPedia context.",
+      evidenceTier: "supplementary",
+      sources: [{ id: "snpedia", name: "SNPedia", url: "https://example.com/snpedia" }],
+      topics: ["SNPedia", "Genotype page"],
+      conditions: ["Male Pattern Baldness"],
+      matchedMarkers: [{ rsid: "rs2003046", genotype: "CC", chromosome: "7", position: 123, gene: undefined }],
+    });
+    installEntries([snpedia]);
+
+    const page = await loadExplorerPage({
+      profileId: "profile-explorer-search",
+      category: "traits",
+      filters: { ...DEFAULT_FILTERS, q: "male pattern baldness" },
+    });
+
+    expect(page.entries.map((entry) => entry.id)).toEqual(["local-traits-snpedia-baldness-context"]);
+  });
+
+  it("returns stable MiniSearch pages with load more cursors", async () => {
     const template = storedEntries()[0];
     installEntries(Array.from({ length: 3 }, (_, index) => withSearchText({
       ...template,
@@ -250,7 +392,7 @@ describe("loadExplorerPage", () => {
     expect(secondPage.hasMore).toBe(false);
   });
 
-  it("preserves Orama result order after IndexedDB hydration", async () => {
+  it("preserves MiniSearch result order after IndexedDB hydration", async () => {
     const template = storedEntries()[0];
     const first = withSearchText({
       ...template,

--- a/src/styles.css
+++ b/src/styles.css
@@ -956,20 +956,55 @@ a { color: inherit; }
   inset-inline: 0;
   bottom: 0;
   z-index: 5;
+  --dn-ai-form-backdrop-rgb: 251, 248, 241;
   padding: 76px 28px 24px;
-  background: linear-gradient(180deg, rgba(251, 248, 241, 0), rgba(251, 248, 241, 0.82) 42%, rgba(251, 248, 241, 0.98) 100%);
+  background: linear-gradient(180deg, rgba(var(--dn-ai-form-backdrop-rgb), 0), rgba(var(--dn-ai-form-backdrop-rgb), 0.82) 42%, rgba(var(--dn-ai-form-backdrop-rgb), 0.98) 100%);
 }
-.dn-ai-follow-ups {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.dn-ai-follow-up-shell {
+  position: relative;
   width: 100%;
   max-width: 715px;
   margin: 0 auto 10px;
 }
+.dn-ai-follow-up-shell::before,
+.dn-ai-follow-up-shell::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  z-index: 2;
+  width: 54px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+.dn-ai-follow-up-shell::before {
+  left: 0;
+  background: linear-gradient(90deg, rgba(var(--dn-ai-form-backdrop-rgb), 0.98), rgba(var(--dn-ai-form-backdrop-rgb), 0));
+}
+.dn-ai-follow-up-shell::after {
+  right: 0;
+  background: linear-gradient(270deg, rgba(var(--dn-ai-form-backdrop-rgb), 0.98), rgba(var(--dn-ai-form-backdrop-rgb), 0));
+}
+.dn-ai-follow-up-shell.has-left-fade::before,
+.dn-ai-follow-up-shell.has-right-fade::after {
+  opacity: 1;
+}
+.dn-ai-follow-ups {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+.dn-ai-follow-ups::-webkit-scrollbar { display: none; }
 .dn-ai-follow-ups button {
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   min-width: 0;
   max-width: 100%;
   min-height: 34px;
@@ -1404,19 +1439,14 @@ a { color: inherit; }
     padding-top: 70px;
     padding-bottom: calc(18px + env(safe-area-inset-bottom));
   }
-  .dn-ai-follow-ups {
-    flex-wrap: nowrap;
+  .dn-ai-follow-up-shell {
     max-width: none;
     margin-inline: -18px;
-    padding-inline: 18px;
-    overflow-x: auto;
-    overscroll-behavior-inline: contain;
-    scrollbar-width: none;
-    -webkit-overflow-scrolling: touch;
   }
-  .dn-ai-follow-ups::-webkit-scrollbar { display: none; }
+  .dn-ai-follow-ups {
+    padding-inline: 18px;
+  }
   .dn-ai-follow-ups button {
-    flex: 0 0 auto;
     max-width: calc(100vw - 36px);
   }
   .dn-ai-search-card { margin-inline: 18px; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -303,6 +303,11 @@ a { color: inherit; }
 }
 @media (prefers-reduced-motion: reduce) {
   .dn-loading-indicator::before { animation-duration: 1.8s; }
+  .dn-ai-follow-ups button {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
 }
 .dn-warning { display: inline-flex; align-items: center; gap: 12px; margin: 24px auto 0; padding: 14px 22px; border-radius: 14px; background: var(--dn-danger-bg); color: var(--dn-clay-dark); font-weight: 700; }
 .dn-processing-card { padding: 30px; margin-top: 20px; text-align: center; }
@@ -602,11 +607,12 @@ a { color: inherit; }
   grid-template-columns: 72px minmax(0, 1fr) minmax(320px, 420px);
 }
 .dn-ai-chat-pane {
+  position: relative;
   min-width: 0;
   height: 100%;
   min-height: 0;
   display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr);
   overflow: hidden;
 }
 .dn-ai-thread-list {
@@ -823,7 +829,8 @@ a { color: inherit; }
 .dn-ai-messages {
   min-height: 280px;
   overflow: auto;
-  padding: 18px 28px;
+  padding: 18px 28px 190px;
+  scroll-padding-bottom: 190px;
 }
 .dn-ai-messages > .dn-ai-status,
 .dn-ai-messages > .dn-ai-error {
@@ -945,8 +952,61 @@ a { color: inherit; }
   color: var(--dn-clay-dark);
 }
 .dn-ai-form {
-  padding: 14px 28px 24px;
-  background: linear-gradient(180deg, rgba(251, 248, 241, 0), rgba(251, 248, 241, 0.95) 26%);
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 5;
+  padding: 76px 28px 24px;
+  background: linear-gradient(180deg, rgba(251, 248, 241, 0), rgba(251, 248, 241, 0.82) 42%, rgba(251, 248, 241, 0.98) 100%);
+}
+.dn-ai-follow-ups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+  max-width: 715px;
+  margin: 0 auto 10px;
+}
+.dn-ai-follow-ups button {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 34px;
+  gap: 7px;
+  border: 1px solid var(--dn-line);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--dn-forest);
+  padding: 5px 11px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  box-shadow: 0 8px 22px rgba(49, 41, 30, 0.06);
+  opacity: 0;
+  transform: translateY(8px);
+  animation: dn-follow-up-in 220ms ease-out forwards;
+}
+.dn-ai-follow-ups button:nth-child(2) { animation-delay: 70ms; }
+.dn-ai-follow-ups button:nth-child(3) { animation-delay: 140ms; }
+.dn-ai-follow-ups button:nth-child(4) { animation-delay: 210ms; }
+.dn-ai-follow-ups button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@keyframes dn-follow-up-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dn-ai-follow-ups button {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
 }
 .dn-ai-composer {
   display: flex;
@@ -1123,6 +1183,14 @@ a { color: inherit; }
 }
 .dn-ai-findings-panel dt { color: var(--dn-ink); font-weight: 600; }
 .dn-ai-findings-panel dd { margin: 0; color: var(--dn-muted); overflow-wrap: anywhere; }
+.dn-ai-show-more-button {
+  width: 100%;
+  min-height: 52px;
+  margin-top: 4px;
+  font-weight: 700;
+  box-shadow: 0 12px 28px rgba(30, 61, 51, 0.2);
+}
+.dn-ai-show-more-button svg { flex: 0 0 auto; }
 .dn-ai-finding-list { display: grid; gap: 10px; }
 .dn-ai-finding-list button {
   display: grid;
@@ -1296,18 +1364,46 @@ a { color: inherit; }
   .dn-raw-marker-card { display: grid; }
   .dn-raw-marker-links { justify-content: flex-start; }
   .dn-filters-modal__header { position: sticky; top: 0; z-index: 2; background: var(--dn-paper); padding-top: 10px; }
-  .dn-ai-screen { display: block; min-height: calc(100vh - 58px); overflow: visible; }
+  .dn-ai-screen {
+    display: block;
+    height: auto;
+    min-height: calc(100dvh - 58px);
+    overflow: visible;
+  }
   .dn-ai-screen:has(.dn-ai-side-panel) { display: block; }
-  .dn-ai-thread-list { display: none; min-height: calc(100vh - 58px); border-right: 0; }
+  .dn-ai-thread-list {
+    display: none;
+    height: auto;
+    min-height: calc(100dvh - 58px);
+    border-right: 0;
+    overflow: visible;
+  }
   .dn-ai-thread-list.is-open { display: block; }
-  .dn-ai-chat-pane { display: none; min-height: calc(100vh - 58px); overflow: visible; }
-  .dn-ai-chat-pane.is-open { display: grid; grid-template-rows: auto minmax(260px, 1fr) auto; }
+  .dn-ai-chat-pane {
+    display: none;
+    height: auto;
+    min-height: calc(100dvh - 58px);
+    overflow: visible;
+  }
+  .dn-ai-screen.is-consent-pending .dn-ai-chat-pane { overflow: visible; }
+  .dn-ai-chat-pane.is-open { display: block; }
   .dn-ai-back { display: inline-flex; }
   .dn-ai-panel__header { display: flex; min-height: auto; padding-block: 14px; }
   .dn-ai-panel__header,
   .dn-ai-context-strip,
   .dn-ai-messages,
   .dn-ai-form { padding-inline: 18px; }
+  .dn-ai-messages {
+    min-height: 0;
+    overflow: visible;
+    padding-bottom: 220px;
+    scroll-padding-bottom: 220px;
+  }
+  .dn-ai-form {
+    position: fixed;
+    padding-top: 70px;
+    padding-bottom: calc(18px + env(safe-area-inset-bottom));
+  }
   .dn-ai-search-card { margin-inline: 18px; }
   .dn-ai-trace__body dl > div { grid-template-columns: 1fr; gap: 2px; }
   .dn-ai-side-panel {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1404,6 +1404,21 @@ a { color: inherit; }
     padding-top: 70px;
     padding-bottom: calc(18px + env(safe-area-inset-bottom));
   }
+  .dn-ai-follow-ups {
+    flex-wrap: nowrap;
+    max-width: none;
+    margin-inline: -18px;
+    padding-inline: 18px;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .dn-ai-follow-ups::-webkit-scrollbar { display: none; }
+  .dn-ai-follow-ups button {
+    flex: 0 0 auto;
+    max-width: calc(100vw - 36px);
+  }
   .dn-ai-search-card { margin-inline: 18px; }
   .dn-ai-trace__body dl > div { grid-template-columns: 1fr; gap: 2px; }
   .dn-ai-side-panel {

--- a/src/types.ts
+++ b/src/types.ts
@@ -353,14 +353,39 @@ export interface ChatTraceFinding {
   sourceNames: string[];
 }
 
+export interface ChatSearchPlan {
+  query: string;
+  categories: InsightCategory[];
+  genes: string[];
+  rsids: string[];
+  topics: string[];
+  conditions: string[];
+  relatedTerms: string[];
+  evidence: EvidenceTier[];
+  rationale: string;
+}
+
+export type ChatTraceSearchPlan = ChatSearchPlan;
+
+export interface ChatRetrievalCursor {
+  hasMore: boolean;
+  nextOffset: number;
+  sentFindingIds: string[];
+}
+
 export interface ChatRetrievalTrace {
   searchedAt: string;
   scannedCategories: InsightCategory[];
   searchedTerms: string[];
   relatedTerms: string[];
   resultCount: number;
+  sentCount?: number;
+  candidateWindowCount?: number;
+  remainingCandidateCount?: number;
   returnedFindings: ChatTraceFinding[];
   rationale: string;
+  searchPlan?: ChatSearchPlan;
+  retrievalCursor?: ChatRetrievalCursor;
   indexCandidateCount?: number;
   usedFallback?: boolean;
   timingMs?: {
@@ -371,6 +396,11 @@ export interface ChatRetrievalTrace {
     fallbackScan: number;
     scoring: number;
   };
+}
+
+export interface ChatFollowUpSuggestion {
+  title: string;
+  body: string;
 }
 
 export interface StoredChatContextFinding {
@@ -426,6 +456,7 @@ export interface StoredChatMessage {
   trace?: ChatRetrievalTrace;
   contextFindings?: StoredChatContextFinding[];
   reasoningSummary?: string | null;
+  followUps?: ChatFollowUpSuggestion[];
 }
 
 export interface ExplorerPage {

--- a/src/workers/searchIndex.worker.ts
+++ b/src/workers/searchIndex.worker.ts
@@ -1,0 +1,53 @@
+import {
+  clearSearchIndex,
+  prewarmSearchIndex,
+  queryCandidateIds,
+  searchExplorerEntryIds,
+  searchWithFields,
+  waitForIndex,
+} from "../lib/ai/searchIndexCore";
+import type { WorkerRequest, WorkerResponse } from "../lib/ai/searchIndexCore";
+
+self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const { type, requestId } = event.data;
+  try {
+    switch (type) {
+      case "prewarm": {
+        await prewarmSearchIndex(event.data.profileId);
+        self.postMessage({ type: "prewarm", requestId } satisfies WorkerResponse);
+        break;
+      }
+      case "waitForIndex": {
+        await waitForIndex(event.data.profileId);
+        self.postMessage({ type: "waitForIndex", requestId } satisfies WorkerResponse);
+        break;
+      }
+      case "searchExplorer": {
+        const result = await searchExplorerEntryIds(event.data.payload);
+        self.postMessage({ type: "searchExplorer", requestId, result } satisfies WorkerResponse);
+        break;
+      }
+      case "searchWithFields": {
+        const result = await searchWithFields(event.data.profileId, event.data.terms, event.data.limit);
+        self.postMessage({ type: "searchWithFields", requestId, result } satisfies WorkerResponse);
+        break;
+      }
+      case "queryCandidates": {
+        const result = await queryCandidateIds(event.data.profileId, event.data.terms, event.data.limit);
+        self.postMessage({ type: "queryCandidates", requestId, result } satisfies WorkerResponse);
+        break;
+      }
+      case "clearIndex": {
+        clearSearchIndex(event.data.profileId, event.data.options);
+        self.postMessage({ type: "clearIndex", requestId } satisfies WorkerResponse);
+        break;
+      }
+    }
+  } catch (err) {
+    self.postMessage({
+      type: "error",
+      requestId,
+      error: err instanceof Error ? err.message : String(err),
+    } satisfies WorkerResponse);
+  }
+};


### PR DESCRIPTION
iOS Safari kills the tab when the main thread spikes memory during Orama
index build/deserialisation. Running all index operations in a Worker
isolates that memory from the page heap so the browser can manage it
independently without crashing the tab.

- searchIndexCore.ts: extracted Orama logic (schema, index build,
  cache, search helpers) — used directly by the worker and as a
  fallback in environments where Worker is unavailable (e.g. tests).
- searchIndex.worker.ts: thin onmessage wrapper around the core
  functions; all Orama state lives in the worker's heap.
- searchIndex.ts: worker client with message-based Promise API;
  falls back to the core directly when Worker is not available so
  existing tests continue to run without changes.
- Reduces explorer search tolerance from 2 to 1 to ease fuzzy-match
  CPU/memory pressure on constrained devices.

https://claude.ai/code/session_01J5vaFtFpR3sUEvMJDV4XD3