### PR TITLE
[codex] Optimise filter improvements

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -25,9 +25,10 @@ import {
 import { EVIDENCE_PACK_VERSION } from "./lib/evidencePack";
 import { prewarmSearchIndex, searchExplorerEntryIds, waitForIndex } from "./lib/ai/searchIndex";
 import { ExplorerFilters, buildEntrySearchText, compareEntries, matchesEntryFilters } from "./lib/explorer";
+import { buildCategoryFacets, buildFacets } from "./lib/reportEngine";
 import {
   makeParsedDnaFile,
-  makeProfileMeta,
+  makeProfileMetaFromProfile,
   makeProfileSummary,
   makeSavedProfile,
 } from "./test/fixtures";
@@ -191,23 +192,7 @@ function profileSummaryFromProfile(profile: SavedProfile): SavedProfileSummary {
 }
 
 function profileMetaFromProfile(profile: SavedProfile): ProfileMeta {
-  return makeProfileMeta({
-    id: profile.id,
-    name: profile.name,
-    fileName: profile.fileName,
-    createdAt: profile.createdAt,
-    dna: profile.dna,
-    supplements: profile.supplements,
-    reportVersion: profile.reportVersion,
-    evidencePackVersion: profile.evidencePackVersion,
-    report: {
-      reportVersion: profile.report.reportVersion,
-      evidencePackVersion: profile.report.evidencePackVersion,
-      overview: profile.report.overview,
-      tabs: profile.report.tabs,
-      facets: profile.report.facets,
-    },
-  });
+  return makeProfileMetaFromProfile(profile);
 }
 
 function storedEntriesFromProfile(profile: SavedProfile): StoredReportEntry[] {
@@ -352,21 +337,56 @@ function makePaginatedProfile(id: string, count: number): SavedProfile {
     },
   }));
 
+  return withReportEntries(profile, medicalEntries, { medical: count, traits: 0, drug: 0 });
+}
+
+function makeTabFacetProfile(id: string): SavedProfile {
+  const profile = makeSavedProfile({ id });
+  const medicalTemplate = profile.report.entries.find((entry) => entry.category === "medical") ?? profile.report.entries[0];
+  const drugTemplate = profile.report.entries.find((entry) => entry.category === "drug") ?? profile.report.entries[0];
+  const entries: SavedProfile["report"]["entries"] = [
+    {
+      ...medicalTemplate,
+      id: "medical-only-facet",
+      category: "medical",
+      title: "Medical only facet",
+      sources: [{ id: "medical-only", name: "Medical Only Source", url: "https://example.com/medical" }],
+      genes: ["MEDGENE"],
+      topics: ["Medical topic"],
+      conditions: ["Medical condition"],
+    },
+    {
+      ...drugTemplate,
+      id: "drug-only-facet",
+      category: "drug",
+      title: "Drug only facet",
+      sources: [{ id: "drug-only", name: "Drug Only Source", url: "https://example.com/drug" }],
+      genes: ["DRUGGENE"],
+      topics: ["Drug topic"],
+      conditions: ["Drug condition"],
+    },
+  ];
+
+  return withReportEntries(profile, entries, { medical: 1, traits: 0, drug: 1 });
+}
+
+function withReportEntries(
+  profile: SavedProfile,
+  entries: SavedProfile["report"]["entries"],
+  counts: { medical: number; traits: number; drug: number },
+): SavedProfile {
   return {
     ...profile,
     report: {
       ...profile.report,
-      entries: medicalEntries,
-      tabs: profile.report.tabs.map((tab) =>
-        tab.tab === "medical"
-          ? { ...tab, count }
-          : tab.tab === "overview"
-            ? { ...tab, count }
-            : { ...tab, count: 0 },
-      ),
-      facets: {
-        ...profile.report.facets,
-      },
+      entries,
+      tabs: profile.report.tabs.map((tab) => {
+        if (tab.tab === "overview") return { ...tab, count: counts.medical + counts.traits + counts.drug };
+        if (tab.tab === "medical" || tab.tab === "traits" || tab.tab === "drug") return { ...tab, count: counts[tab.tab] };
+        return { ...tab, count: 0 };
+      }),
+      facets: buildFacets(entries),
+      categoryFacets: buildCategoryFacets(entries),
     },
   };
 }
@@ -735,6 +755,58 @@ describe("Deana app", () => {
     );
   });
 
+  it("clears tab-scoped filters when switching category tabs", async () => {
+    const user = userEvent.setup();
+    storedProfiles = [makeTabFacetProfile("profile-tab-filter-reset")];
+
+    renderApp("/explorer/profile-tab-filter-reset?tab=medical");
+
+    await screen.findByText("Current report");
+    await user.selectOptions(screen.getByLabelText("Source"), "Medical Only Source");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location").textContent).toContain("source=Medical+Only+Source"),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Drug response" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location").textContent).toContain("tab=drug"),
+    );
+    expect(screen.getByTestId("location").textContent).not.toContain("source=");
+    await waitFor(() =>
+      expect(vi.mocked(loadCategoryPage).mock.calls.some(([request]) =>
+        request.category === "drug" &&
+        request.filters.source === "" &&
+        request.filters.evidence.length === 0 &&
+        request.filters.sort === "rank",
+      )).toBe(true),
+    );
+  });
+
+  it("renders only the facet options for the active category tab", async () => {
+    const user = userEvent.setup();
+    storedProfiles = [makeTabFacetProfile("profile-category-facets")];
+
+    renderApp("/explorer/profile-category-facets?tab=medical");
+
+    await screen.findByText("Current report");
+    const medicalSource = screen.getByLabelText("Source");
+    expect(within(medicalSource).getByRole("option", { name: "Medical Only Source" })).toBeInTheDocument();
+    expect(within(medicalSource).queryByRole("option", { name: "Drug Only Source" })).not.toBeInTheDocument();
+    expect(screen.getAllByText("MEDGENE").length).toBeGreaterThan(0);
+    expect(screen.queryByText("DRUGGENE")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Drug response" }));
+    await screen.findByText("Drug response explorer");
+
+    const drugSource = screen.getByLabelText("Source");
+    expect(within(drugSource).getByRole("option", { name: "Drug Only Source" })).toBeInTheDocument();
+    expect(within(drugSource).queryByRole("option", { name: "Medical Only Source" })).not.toBeInTheDocument();
+    expect(screen.getAllByText("DRUGGENE").length).toBeGreaterThan(0);
+    expect(screen.queryByText("MEDGENE")).not.toBeInTheDocument();
+  });
+
   it("gates AI chat behind explicit consent without making a request on tab open", async () => {
     const user = userEvent.setup();
     storedProfiles = [makeSavedProfile({ id: "profile-ai" })];
@@ -1001,6 +1073,24 @@ describe("Deana app", () => {
 
     expect(await screen.findByText("55 visible results")).toBeInTheDocument();
     expect(screen.getByText("Medical finding 55")).toBeInTheDocument();
+  });
+
+  it("mounts a fresh category list with top scroll when switching tabs", async () => {
+    const user = userEvent.setup();
+    storedProfiles = [makeTabFacetProfile("profile-tab-remount")];
+
+    const { container } = renderApp("/explorer/profile-tab-remount?tab=medical");
+
+    await screen.findByText("Current report");
+    const medicalPanel = container.querySelector(".dn-finding-list-panel") as HTMLElement;
+    medicalPanel.scrollTop = 180;
+
+    await user.click(screen.getByRole("button", { name: "Drug response" }));
+    await screen.findByText("Drug response explorer");
+
+    const drugPanel = container.querySelector(".dn-finding-list-panel") as HTMLElement;
+    expect(drugPanel).not.toBe(medicalPanel);
+    expect(drugPanel.scrollTop).toBe(0);
   });
 
   it("loads the selected entry for the inspector even when it is not in the first page", async () => {

--- a/src/components/deana/explorer.tsx
+++ b/src/components/deana/explorer.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
-import type { ExplorerFilters } from "../../lib/explorer";
-import type { ExplorerTab, InsightCategory, ProfileMeta, ReportEntry, StoredReportEntry } from "../../types";
+import { memo, useCallback, useEffect, useId, useMemo, useRef, useState, type DependencyList, type ReactNode, type RefObject } from "react";
+import { SORT_FILTER_OPTIONS, type ExplorerFilters } from "../../lib/explorer";
+import type { ExplorerTab, InsightCategory, ProfileMeta, ReportEntry, ReportFacets, StoredReportEntry } from "../../types";
 import { DEANA_GITHUB_URL, PrivacyModal, SupportDeanaModal } from "./marketing";
 import { DeanaWordmark, Icon, IconName } from "./ui";
 
@@ -34,13 +34,13 @@ const nav: Array<{ id: ExplorerTab; label: string; icon: IconName }> = tabs.map(
 }));
 const visibleTabsWithoutAi = tabs.filter((item) => item.id !== "ai");
 const visibleNavWithoutAi = nav.filter((item) => item.id !== "ai");
-const SORT_FILTER_OPTIONS: Array<[string, string]> = [
-  ["rank", "Best evidence match"],
-  ["severity", "Severity / priority"],
-  ["evidence", "Evidence strength"],
-  ["publications", "Publication count"],
-  ["alphabetical", "Alphabetical"],
-];
+
+function useScrollTopOnChange<T extends HTMLElement>(ref: RefObject<T | null>, deps: DependencyList) {
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.scrollTop = 0;
+  }, deps);
+}
 
 export function ExplorerShell({
   report,
@@ -309,7 +309,7 @@ export function OverviewContent({
 
 export function CategoryExplorerContent({
   activeTab,
-  profile,
+  facets,
   filters,
   entries,
   selectedEntry,
@@ -326,7 +326,7 @@ export function CategoryExplorerContent({
   onLoadMore,
 }: {
   activeTab: InsightCategory;
-  profile: ProfileMeta;
+  facets: ReportFacets;
   filters: ExplorerFilters;
   entries: StoredReportEntry[];
   selectedEntry: StoredReportEntry | null;
@@ -344,13 +344,23 @@ export function CategoryExplorerContent({
 }) {
   const [areFiltersCollapsed, setAreFiltersCollapsed] = useState(false);
   const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false);
+  const listPanelRef = useRef<HTMLElement | null>(null);
+  const onSelectEntryRef = useRef(onSelectEntry);
   const filterFormProps = {
-    profile,
+    facets,
     filters,
     searchValue,
     onFilterChange,
     onSearchChange,
   };
+  const handleSelectEntry = useCallback((id: string) => {
+    onSelectEntryRef.current(id);
+  }, []);
+
+  useEffect(() => {
+    onSelectEntryRef.current = onSelectEntry;
+  }, [onSelectEntry]);
+  useScrollTopOnChange(listPanelRef, []);
 
   return (
     <main className={`dn-category-screen ${areFiltersCollapsed ? "is-filter-collapsed" : ""}`}>
@@ -387,7 +397,7 @@ export function CategoryExplorerContent({
         )}
       </aside>
 
-      <section className="dn-finding-list-panel">
+      <section ref={listPanelRef} className="dn-finding-list-panel">
         <div className="dn-category-title-row">
           <div>
             <h1>{titleForTab(activeTab)}</h1>
@@ -403,7 +413,7 @@ export function CategoryExplorerContent({
 
         <div className="dn-finding-list">
           {entries.map((entry) => (
-            <FindingCard key={entry.id} entry={entry} selected={entry.id === selectedEntry?.id} onClick={() => onSelectEntry(entry.id)} />
+            <FindingCard key={entry.id} entry={entry} selected={entry.id === selectedEntry?.id} onSelect={handleSelectEntry} />
           ))}
           {entries.length === 0 && !isLoading ? (
             <div className="dn-empty-state">
@@ -458,57 +468,56 @@ export function CategoryExplorerContent({
 }
 
 function ExplorerFiltersForm({
-  profile,
+  facets,
   filters,
   searchValue,
   onFilterChange,
   onSearchChange,
 }: {
-  profile: ProfileMeta;
+  facets: ReportFacets;
   filters: ExplorerFilters;
   searchValue: string;
   onFilterChange: <K extends keyof ExplorerFilters>(key: K, value: ExplorerFilters[K]) => void;
   onSearchChange: (value: string) => void;
 }) {
   const sourceOptions = useMemo(
-    () => optionList(profile.report.facets.sources, "All sources"),
-    [profile.report.facets.sources],
+    () => optionList(facets.sources, "All sources"),
+    [facets.sources],
   );
   const evidenceOptions = useMemo(
-    () => profile.report.facets.evidenceTiers.map((value): [string, string] => [value, value]),
-    [profile.report.facets.evidenceTiers],
+    () => facets.evidenceTiers.map((value): [string, string] => [value, value]),
+    [facets.evidenceTiers],
   );
   const clinicalSignificanceOptions = useMemo(
     () =>
-      profile.report.facets.clinicalSignificances.map((value): [string, string] => [
+      facets.clinicalSignificances.map((value): [string, string] => [
         value,
-        profile.report.facets.clinicalSignificanceLabels[value] ?? value,
+        facets.clinicalSignificanceLabels[value] ?? value,
       ]),
-    [profile.report.facets.clinicalSignificanceLabels, profile.report.facets.clinicalSignificances],
+    [facets.clinicalSignificanceLabels, facets.clinicalSignificances],
   );
   const reputeOptions = useMemo(
-    () => profile.report.facets.reputes.map((value): [string, string] => [value, value]),
-    [profile.report.facets.reputes],
+    () => facets.reputes.map((value): [string, string] => [value, value]),
+    [facets.reputes],
   );
   const coverageOptions = useMemo(
-    () => profile.report.facets.coverages.map((value): [string, string] => [value, value]),
-    [profile.report.facets.coverages],
+    () => facets.coverages.map((value): [string, string] => [value, value]),
+    [facets.coverages],
   );
   const publicationOptions = useMemo(
-    () => profile.report.facets.publicationBuckets.map((value): [string, string] => [value, value]),
-    [profile.report.facets.publicationBuckets],
+    () => facets.publicationBuckets.map((value): [string, string] => [value, value]),
+    [facets.publicationBuckets],
   );
   const geneOptions = useMemo(
-    () => profile.report.facets.genes.map((value): [string, string] => [value, value]),
-    [profile.report.facets.genes],
+    () => facets.genes.map((value): [string, string] => [value, value]),
+    [facets.genes],
   );
   const tagOptions = useMemo(
     () =>
-      [...profile.report.facets.tags, ...profile.report.facets.conditions]
-        .filter((value, index, array) => array.indexOf(value) === index)
+      Array.from(new Set([...facets.tags, ...facets.conditions]))
         .sort()
         .map((value): [string, string] => [value, value]),
-    [profile.report.facets.conditions, profile.report.facets.tags],
+    [facets.conditions, facets.tags],
   );
 
   return (
@@ -540,13 +549,24 @@ function ExplorerFiltersForm({
   );
 }
 
-function FindingCard({ entry, selected, onClick }: { entry: StoredReportEntry; selected?: boolean; onClick?: () => void }) {
+const FindingCard = memo(function FindingCard({
+  entry,
+  selected,
+  onSelect,
+}: {
+  entry: StoredReportEntry;
+  selected?: boolean;
+  onSelect: (id: string) => void;
+}) {
   const firstMarker = entry.matchedMarkers[0];
   const summary = summaryUnlessTitle(entry.summary, entry.title);
   const snapshot = evidenceSnapshotItems(entry);
+  const handleClick = useCallback(() => {
+    onSelect(entry.id);
+  }, [entry.id, onSelect]);
 
   return (
-    <button className={`dn-finding-card ${selected ? "is-selected" : ""} dn-finding-tone-${toneForEntry(entry)}`} onClick={onClick}>
+    <button className={`dn-finding-card ${selected ? "is-selected" : ""} dn-finding-tone-${toneForEntry(entry)}`} onClick={handleClick}>
         <span className="dn-finding-card__icon"><Icon name={iconForTab(entry.category)} /></span>
       <div className="dn-finding-card__main">
         <div className="dn-finding-card__meta">
@@ -575,7 +595,7 @@ function FindingCard({ entry, selected, onClick }: { entry: StoredReportEntry; s
       <Icon name="external" />
     </button>
   );
-}
+});
 
 export function FindingInspector({
   finding,
@@ -589,11 +609,7 @@ export function FindingInspector({
   emptyContent?: ReactNode;
 }) {
   const inspectorRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (!inspectorRef.current) return;
-    inspectorRef.current.scrollTop = 0;
-  }, [finding?.id]);
+  useScrollTopOnChange(inspectorRef, [finding?.id]);
 
   if (!finding) {
     return (

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -26,6 +26,14 @@ export const DEFAULT_FILTERS: ExplorerFilters = {
   sort: "rank",
 };
 
+export const SORT_FILTER_OPTIONS: Array<[ExplorerFilters["sort"], string]> = [
+  ["rank", "Best evidence match"],
+  ["severity", "Severity / priority"],
+  ["evidence", "Evidence strength"],
+  ["publications", "Publication count"],
+  ["alphabetical", "Alphabetical"],
+];
+
 type SearchableEntry = {
   searchText?: string;
   id?: string;

--- a/src/lib/reportEngine.test.ts
+++ b/src/lib/reportEngine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ensureCurrentProfile } from "./storage";
 import { EVIDENCE_PACK_VERSION, SOURCE_LIBRARY } from "./evidencePack";
-import { generateReport, REPORT_VERSION } from "./reportEngine";
+import { buildCategoryFacets, buildFacets, generateReport, REPORT_VERSION } from "./reportEngine";
 import { makeParsedDnaFile, makeSavedProfile } from "../test/fixtures";
 import type { EvidenceSupplement } from "../types";
 
@@ -16,6 +16,9 @@ describe("reportEngine", () => {
     expect(report.facets.sources).toContain("ClinVar");
     expect(report.facets.genes).toContain("APOE");
     expect(report.facets.clinicalSignificanceLabels["risk-context"]).toBe("Risk context");
+    expect(report.categoryFacets.medical.sources).toContain("ClinVar");
+    expect(report.categoryFacets.medical.genes).toContain("APOE");
+    expect(report.categoryFacets.drug.genes).not.toContain("APOE");
     expect(report.entries[0]).toMatchObject({
       id: expect.any(String),
       category: expect.any(String),
@@ -29,6 +32,7 @@ describe("reportEngine", () => {
   });
 
   it("regenerates legacy saved profiles to the current report version", () => {
+    const emptyFacets = buildFacets([]);
     const legacyProfile = makeSavedProfile({
       reportVersion: 1,
       evidencePackVersion: "legacy-pack",
@@ -56,18 +60,8 @@ describe("reportEngine", () => {
         },
         tabs: [],
         entries: [],
-        facets: {
-          sources: [],
-          evidenceTiers: [],
-          coverages: [],
-          reputes: [],
-          clinicalSignificances: [],
-          clinicalSignificanceLabels: {},
-          genes: [],
-          tags: [],
-          conditions: [],
-          publicationBuckets: [],
-        },
+        facets: emptyFacets,
+        categoryFacets: buildCategoryFacets([]),
       },
     });
 

--- a/src/lib/reportEngine.ts
+++ b/src/lib/reportEngine.ts
@@ -5,6 +5,7 @@ import {
   EvidencePackMatch,
   EvidenceSupplement,
   EvidenceTier,
+  InsightCategory,
   InsightTone,
   ParsedDnaFile,
   ProfileSupplements,
@@ -43,7 +44,7 @@ function facetValues<T extends string>(values: readonly T[], preferred: readonly
   return preferred.filter((value) => values.includes(value));
 }
 
-function buildFacets(entries: ReportEntry[]): ReportFacets {
+export function buildFacets(entries: ReportEntry[]): ReportFacets {
   const clinicalSignificances = uniq(
     entries
       .map((entry) => entry.normalizedClinicalSignificance)
@@ -75,6 +76,24 @@ function buildFacets(entries: ReportEntry[]): ReportFacets {
       uniq(entries.map((entry) => entry.publicationBucket)) as Array<ReportEntry["publicationBucket"]>,
       ["0", "1-5", "6-20", "21+"],
     ),
+  };
+}
+
+export function buildCategoryFacets(entries: ReportEntry[]): Record<InsightCategory, ReportFacets> {
+  const entriesByCategory: Record<InsightCategory, ReportEntry[]> = {
+    medical: [],
+    traits: [],
+    drug: [],
+  };
+
+  for (const entry of entries) {
+    entriesByCategory[entry.category].push(entry);
+  }
+
+  return {
+    medical: buildFacets(entriesByCategory.medical),
+    traits: buildFacets(entriesByCategory.traits),
+    drug: buildFacets(entriesByCategory.drug),
   };
 }
 
@@ -400,5 +419,6 @@ export function generateReport(dna: ParsedDnaFile, supplements?: ProfileSuppleme
     tabs: buildTabs(entries),
     entries,
     facets: buildFacets(entries),
+    categoryFacets: buildCategoryFacets(entries),
   };
 }

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -48,6 +48,22 @@ describe("profile storage normalization", () => {
     expect(normalized.report.entries.length).toBeGreaterThan(1);
   });
 
+  it("regenerates current-version profiles that are missing category facets", () => {
+    const profile = makeSavedProfile();
+    const legacyProfile = {
+      ...profile,
+      report: {
+        ...profile.report,
+        categoryFacets: undefined,
+      },
+    } as unknown as typeof profile;
+    const normalized = ensureCurrentProfile(legacyProfile);
+
+    expect(normalized.report.categoryFacets.medical.sources.length).toBeGreaterThan(0);
+    expect(normalized.report.categoryFacets.medical.genes).toContain("APOE");
+    expect(normalized.report.categoryFacets.drug.genes).not.toContain("APOE");
+  });
+
   it("strips heavyweight evidence match records from profile metadata supplements", () => {
     const dna = makeParsedDnaFile();
     const supplement: EvidenceSupplement = {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,9 +1,11 @@
 import { EVIDENCE_PACK_VERSION } from "./evidencePack";
 import { DEFAULT_FILTERS, ExplorerFilters, buildEntrySearchText, matchesEntryFilters } from "./explorer";
-import { generateReport, REPORT_VERSION } from "./reportEngine";
+import { buildCategoryFacets, generateReport, REPORT_VERSION } from "./reportEngine";
 import {
   ExplorerPage,
   AiConsentAcceptance,
+  INSIGHT_CATEGORIES,
+  InsightCategory,
   ParsedDnaFile,
   ProfileMeta,
   ProfileSupplements,
@@ -232,10 +234,18 @@ function hasCurrentReportShape(profile: SavedProfile): boolean {
       profile.report.entries.every((entry) => typeof entry.sort?.rank === "number") &&
       !profile.report?.tabs?.some((tab) => (tab.tab as string) === "other") &&
       profile.report?.facets?.clinicalSignificanceLabels &&
+      hasCategoryFacets(profile.report) &&
       typeof profile.report?.overview?.localEvidenceEntryMatches === "number" &&
       typeof profile.report?.overview?.localEvidenceRecordMatches === "number" &&
       typeof profile.report?.overview?.localEvidenceMatchedRsids === "number",
   );
+}
+
+function hasCategoryFacets(report: Partial<Pick<ReportDataMeta, "categoryFacets">>): boolean {
+  return INSIGHT_CATEGORIES.every((category) => {
+    const facets = report.categoryFacets?.[category];
+    return Boolean(facets?.clinicalSignificanceLabels);
+  });
 }
 
 function profileNeedsReportShapeRegeneration(profile: {
@@ -305,6 +315,7 @@ function toReportMeta(report: SavedProfile["report"]): ReportDataMeta {
     overview: report.overview,
     tabs: report.tabs,
     facets: report.facets,
+    categoryFacets: report.categoryFacets,
   };
 }
 
@@ -576,7 +587,38 @@ export async function loadProfileMeta(profileId: string): Promise<ProfileMeta | 
     };
   }
 
+  if (!hasCategoryFacets(profile.report)) {
+    return refreshProfileCategoryFacets(profile, metaRecord);
+  }
+
   return profile;
+}
+
+async function refreshProfileCategoryFacets(
+  profile: ProfileMeta,
+  metaRecord: StoredProfileMetaRecord,
+): Promise<ProfileMeta> {
+  const db = await openDb();
+  const entriesTransaction = db.transaction(REPORT_ENTRY_STORE, "readonly");
+  const entries = await loadReportEntriesForProfile(entriesTransaction.objectStore(REPORT_ENTRY_STORE), profile.id);
+  const categoryFacets = buildCategoryFacets(entries);
+  const refreshed = {
+    ...profile,
+    report: {
+      ...profile.report,
+      categoryFacets,
+    },
+  };
+
+  const metaTransaction = db.transaction(PROFILE_META_STORE, "readwrite");
+  const done = transactionToPromise(metaTransaction);
+  metaTransaction.objectStore(PROFILE_META_STORE).put({
+    ...metaRecord,
+    report: refreshed.report,
+  } satisfies StoredProfileMetaRecord);
+  await done;
+
+  return refreshed;
 }
 
 export async function loadCategoryPage({
@@ -801,7 +843,7 @@ export async function* streamReportEntries(
   profileId: string,
   category?: StoredReportEntry["category"],
 ): AsyncGenerator<StoredReportEntry> {
-  const categories = category ? [category] : (["medical", "traits", "drug"] as const);
+  const categories = category ? [category] : INSIGHT_CATEGORIES;
 
   for (const activeCategory of categories) {
     const entries = await loadAllEntriesForCategory(profileId, activeCategory);

--- a/src/screens/ExplorerScreen.tsx
+++ b/src/screens/ExplorerScreen.tsx
@@ -11,6 +11,7 @@ import { ExplorerAiChat } from "../components/deana/aiChat";
 import {
   DEFAULT_FILTERS,
   ExplorerFilters,
+  SORT_FILTER_OPTIONS,
   matchesEntryFilters,
 } from "../lib/explorer";
 import {
@@ -20,7 +21,7 @@ import {
 import { loadExplorerPage } from "../lib/explorerSearch";
 import { EVIDENCE_PACK_VERSION } from "../lib/evidencePack";
 import { prewarmSearchIndex } from "../lib/ai/searchIndex";
-import { ExplorerTab, ProfileMeta, ReportEntry, StoredReportEntry } from "../types";
+import { ExplorerTab, InsightCategory, ProfileMeta, ReportFacets, StoredReportEntry } from "../types";
 
 interface ExplorerScreenProps {
   isLibraryReady: boolean;
@@ -30,6 +31,7 @@ const PAGE_SIZE = 50;
 const SEARCH_DEBOUNCE_MS = 300;
 const MULTI_FILTER_KEYS = ["evidence", "significance", "repute", "coverage", "publications", "gene", "tag"] as const;
 const RESET_FILTER_KEYS = ["q", "source", "sort", ...MULTI_FILTER_KEYS] as const;
+const SORT_FILTER_VALUES = new Set(SORT_FILTER_OPTIONS.map(([value]) => value));
 
 function formatFilters(searchParams: URLSearchParams): ExplorerFilters {
   const multiValue = (key: (typeof MULTI_FILTER_KEYS)[number]): string[] => {
@@ -56,7 +58,11 @@ function formatFilters(searchParams: URLSearchParams): ExplorerFilters {
   };
 }
 
-function categoryForTab(tab: ExplorerTab): ReportEntry["category"] | undefined {
+function filterSearchKey(searchParams: URLSearchParams): string {
+  return RESET_FILTER_KEYS.map((key) => `${key}=${searchParams.getAll(key).join(",")}`).join("&");
+}
+
+function categoryForTab(tab: ExplorerTab): InsightCategory | undefined {
   if (tab === "medical") return "medical";
   if (tab === "traits") return "traits";
   if (tab === "drug") return "drug";
@@ -121,6 +127,30 @@ function resetFilterPatch(): Partial<Record<string, null>> {
   return Object.fromEntries([...RESET_FILTER_KEYS, "selected"].map((key) => [key, null]));
 }
 
+function sanitizeFilterPatch(filters: ExplorerFilters, facets: ReportFacets): Partial<Record<string, string | string[] | null>> {
+  const patch: Partial<Record<string, string | string[] | null>> = {};
+  const keepKnownValues = (key: (typeof MULTI_FILTER_KEYS)[number], allowedValues: string[]) => {
+    const allowed = new Set(allowedValues);
+    const current = filters[key];
+    const next = current.filter((value) => allowed.has(value));
+    if (next.length !== current.length) {
+      patch[key] = next.length > 0 ? next : null;
+    }
+  };
+
+  if (filters.source && !facets.sources.includes(filters.source)) patch.source = null;
+  if (!SORT_FILTER_VALUES.has(filters.sort)) patch.sort = null;
+  keepKnownValues("evidence", facets.evidenceTiers);
+  keepKnownValues("significance", facets.clinicalSignificances);
+  keepKnownValues("repute", facets.reputes);
+  keepKnownValues("coverage", facets.coverages);
+  keepKnownValues("publications", facets.publicationBuckets);
+  keepKnownValues("gene", facets.genes);
+  keepKnownValues("tag", [...facets.tags, ...facets.conditions]);
+
+  return patch;
+}
+
 function scheduleSearchIndexPrewarm(profileId: string): () => void {
   let cancelled = false;
   const run = () => {
@@ -174,23 +204,14 @@ export function ExplorerScreen({
   const { profileId } = useParams<{ profileId: string }>();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(() => Boolean(searchParams.get("selected")));
   const [isProfileLoading, setIsProfileLoading] = useState(true);
-  const [isPageLoading, setIsPageLoading] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [profile, setProfile] = useState<ProfileMeta | null>(null);
-  const [visibleEntries, setVisibleEntries] = useState<StoredReportEntry[]>([]);
-  const [pageCursor, setPageCursor] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
-  const [selectedEntryFallback, setSelectedEntryFallback] = useState<StoredReportEntry | null>(null);
   const [isAiEnabled, setIsAiEnabled] = useState<boolean | null>(null);
 
-  const searchKey = searchParams.toString();
-  const tab = useMemo(() => normalizeTab(searchParams.get("tab")), [searchKey]);
-  const filters = useMemo(() => formatFilters(searchParams), [searchKey]);
-  const [searchInput, setSearchInput] = useState(filters.q);
+  const filterKey = useMemo(() => filterSearchKey(searchParams), [searchParams]);
+  const tab = useMemo(() => normalizeTab(searchParams.get("tab")), [searchParams]);
+  const filters = useMemo(() => formatFilters(searchParams), [filterKey]);
   const category = categoryForTab(tab);
-  const selectedEntryId = searchParams.get("selected") ?? "";
   const evidencePackStatus = getEvidencePackStatus(profile);
 
   useEffect(() => {
@@ -210,12 +231,6 @@ export function ExplorerScreen({
       updateSearchParams(searchParams, { tab: "overview", selected: null }, setSearchParams);
     }
   }, [isAiEnabled, searchParams, setSearchParams, tab]);
-
-  useEffect(() => {
-    if (!selectedEntryId) {
-      setIsMobileSheetOpen(false);
-    }
-  }, [selectedEntryId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -246,103 +261,6 @@ export function ExplorerScreen({
     return scheduleSearchIndexPrewarm(profile.id);
   }, [profile?.id]);
 
-  useEffect(() => {
-    setSearchInput(filters.q);
-  }, [filters.q, profile?.id, tab]);
-
-  useEffect(() => {
-    if (searchInput === filters.q) return;
-
-    const handle = setTimeout(() => {
-      commitSearchInput(searchInput);
-    }, SEARCH_DEBOUNCE_MS);
-
-    return () => clearTimeout(handle);
-  }, [filters.q, searchInput, searchParams, setSearchParams]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!profile || !category) {
-      startTransition(() => {
-        setVisibleEntries([]);
-        setPageCursor(null);
-        setHasMore(false);
-      });
-      return;
-    }
-
-    setIsPageLoading(true);
-
-    void loadExplorerPage({
-      profileId: profile.id,
-      category,
-      filters,
-      pageSize: PAGE_SIZE,
-    })
-      .then((page) => {
-        if (cancelled) return;
-        startTransition(() => {
-          setVisibleEntries(page.entries);
-          setPageCursor(page.nextCursor);
-          setHasMore(page.hasMore);
-          setSelectedEntryFallback(null);
-        });
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setIsPageLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [category, filters, profile]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!profile || !category || !selectedEntryId) {
-      startTransition(() => {
-        setSelectedEntryFallback(null);
-      });
-      return;
-    }
-
-    if (visibleEntries.some((entry) => entry.id === selectedEntryId)) {
-      startTransition(() => {
-        setSelectedEntryFallback(null);
-      });
-      return;
-    }
-
-    void loadReportEntry(profile.id, selectedEntryId).then((entry) => {
-      if (cancelled) return;
-      startTransition(() => {
-        setSelectedEntryFallback(
-          entry &&
-            matchesEntryFilters(entry, filters, category)
-            ? entry
-            : null,
-        );
-      });
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [category, filters, profile, selectedEntryId, visibleEntries]);
-
-  const selectedEntry = useMemo(() => {
-    return visibleEntries.find((entry) => entry.id === selectedEntryId) ?? selectedEntryFallback;
-  }, [selectedEntryFallback, selectedEntryId, visibleEntries]);
-
-  useEffect(() => {
-    if (!category || tab === "overview") return;
-    if (selectedEntryId || visibleEntries.length === 0) return;
-    updateSearchParams(searchParams, { selected: visibleEntries[0].id }, setSearchParams);
-  }, [category, searchParams, selectedEntryId, setSearchParams, tab, visibleEntries]);
-
   if (!isLibraryReady || isProfileLoading) {
     return (
       <main className="dn-loading-screen" aria-live="polite" aria-busy="true">
@@ -359,60 +277,12 @@ export function ExplorerScreen({
 
   function setTab(nextTab: ExplorerTab) {
     if (nextTab === "ai" && isAiEnabled !== true) return;
-    setIsMobileSheetOpen(false);
+    if (nextTab === tab) return;
     updateSearchParams(
       searchParams,
-      { tab: nextTab, selected: nextTab === "overview" || nextTab === "ai" ? null : "" },
+      { ...resetFilterPatch(), tab: nextTab },
       setSearchParams,
     );
-  }
-
-  function setFilter<K extends keyof ExplorerFilters>(key: K, value: ExplorerFilters[K]) {
-    setIsMobileSheetOpen(false);
-    updateSearchParams(searchParams, { [key]: value || null, selected: null }, setSearchParams);
-  }
-
-  function setSearchFilter(value: string) {
-    setIsMobileSheetOpen(false);
-    setSearchInput(value);
-  }
-
-  function commitSearchInput(value: string) {
-    updateSearchParams(searchParams, { q: value || null, selected: null }, setSearchParams);
-  }
-
-  function resetFilters() {
-    setIsMobileSheetOpen(false);
-    setSearchInput("");
-    updateSearchParams(searchParams, resetFilterPatch(), setSearchParams);
-  }
-
-  function selectCategoryEntry(id: string) {
-    setIsMobileSheetOpen(true);
-    updateSearchParams(searchParams, { selected: id }, setSearchParams);
-  }
-
-  async function handleLoadMore() {
-    if (!profile || !category || !pageCursor || isLoadingMore) return;
-
-    setIsLoadingMore(true);
-    try {
-      const page = await loadExplorerPage({
-        profileId: profile.id,
-        category,
-        filters,
-        cursor: pageCursor,
-        pageSize: PAGE_SIZE,
-      });
-
-      startTransition(() => {
-        setVisibleEntries((current) => [...current, ...page.entries]);
-        setPageCursor(page.nextCursor);
-        setHasMore(page.hasMore);
-      });
-    } finally {
-      setIsLoadingMore(false);
-    }
   }
 
   return (
@@ -438,32 +308,227 @@ export function ExplorerScreen({
         <ExplorerAiChat
           profile={profile}
           currentTab={tab}
-          filters={filters}
-          visibleEntries={visibleEntries}
-          selectedEntry={selectedEntry}
+          filters={DEFAULT_FILTERS}
+          visibleEntries={[]}
+          selectedEntry={null}
         />
       ) : tab === "ai" ? (
         <OverviewContent profile={profile} onExploreCategory={setTab} />
-      ) : (
-        <CategoryExplorerContent
-          activeTab={tab}
+      ) : category ? (
+        <CategoryExplorerPane
+          key={`${profile.id}:${category}`}
+          activeTab={category}
           profile={profile}
+          facets={profile.report.categoryFacets[category]}
           filters={filters}
-          entries={visibleEntries}
-          selectedEntry={selectedEntry}
-          isLoading={isPageLoading}
-          hasMore={hasMore}
-          isLoadingMore={isLoadingMore}
-          isMobileSheetOpen={isMobileSheetOpen}
-          searchValue={searchInput}
-          onFilterChange={setFilter}
-          onSearchChange={setSearchFilter}
-          onResetFilters={resetFilters}
-          onSelectEntry={selectCategoryEntry}
-          onCloseMobileSheet={() => setIsMobileSheetOpen(false)}
-          onLoadMore={() => void handleLoadMore()}
+          searchParams={searchParams}
+          setSearchParams={setSearchParams}
         />
-      )}
+      ) : null}
     </ExplorerShell>
+  );
+}
+
+function CategoryExplorerPane({
+  activeTab,
+  profile,
+  facets,
+  filters,
+  searchParams,
+  setSearchParams,
+}: {
+  activeTab: InsightCategory;
+  profile: ProfileMeta;
+  facets: ReportFacets;
+  filters: ExplorerFilters;
+  searchParams: URLSearchParams;
+  setSearchParams: ReturnType<typeof useSearchParams>[1];
+}) {
+  const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(() => Boolean(searchParams.get("selected")));
+  const [isPageLoading, setIsPageLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [visibleEntries, setVisibleEntries] = useState<StoredReportEntry[]>([]);
+  const [pageCursor, setPageCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [selectedEntryFallback, setSelectedEntryFallback] = useState<StoredReportEntry | null>(null);
+  const [searchInput, setSearchInput] = useState(filters.q);
+  const selectedEntryId = searchParams.get("selected") ?? "";
+  const sanitizedFilterPatch = useMemo(
+    () => sanitizeFilterPatch(filters, facets),
+    [
+      facets,
+      filters.source,
+      filters.evidence,
+      filters.significance,
+      filters.repute,
+      filters.coverage,
+      filters.publications,
+      filters.gene,
+      filters.tag,
+      filters.sort,
+    ],
+  );
+
+  useEffect(() => {
+    if (Object.keys(sanitizedFilterPatch).length === 0) return;
+    updateSearchParams(searchParams, { ...sanitizedFilterPatch, selected: null }, setSearchParams);
+  }, [sanitizedFilterPatch, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (!selectedEntryId) {
+      setIsMobileSheetOpen(false);
+    }
+  }, [selectedEntryId]);
+
+  useEffect(() => {
+    setSearchInput(filters.q);
+  }, [filters.q, profile.id, activeTab]);
+
+  useEffect(() => {
+    if (searchInput === filters.q) return;
+
+    const handle = setTimeout(() => {
+      updateSearchParams(searchParams, { q: searchInput || null, selected: null }, setSearchParams);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [filters.q, searchInput, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setIsPageLoading(true);
+
+    void loadExplorerPage({
+      profileId: profile.id,
+      category: activeTab,
+      filters,
+      pageSize: PAGE_SIZE,
+    })
+      .then((page) => {
+        if (cancelled) return;
+        startTransition(() => {
+          setVisibleEntries(page.entries);
+          setPageCursor(page.nextCursor);
+          setHasMore(page.hasMore);
+          setSelectedEntryFallback(null);
+        });
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsPageLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, filters, profile.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!selectedEntryId) {
+      startTransition(() => {
+        setSelectedEntryFallback(null);
+      });
+      return;
+    }
+
+    if (visibleEntries.some((entry) => entry.id === selectedEntryId)) {
+      startTransition(() => {
+        setSelectedEntryFallback(null);
+      });
+      return;
+    }
+
+    void loadReportEntry(profile.id, selectedEntryId).then((entry) => {
+      if (cancelled) return;
+      startTransition(() => {
+        setSelectedEntryFallback(
+          entry &&
+            matchesEntryFilters(entry, filters, activeTab)
+            ? entry
+            : null,
+        );
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, filters, profile.id, selectedEntryId, visibleEntries]);
+
+  const selectedEntry = useMemo(() => {
+    return visibleEntries.find((entry) => entry.id === selectedEntryId) ?? selectedEntryFallback;
+  }, [selectedEntryFallback, selectedEntryId, visibleEntries]);
+
+  useEffect(() => {
+    if (selectedEntryId || visibleEntries.length === 0) return;
+    updateSearchParams(searchParams, { selected: visibleEntries[0].id }, setSearchParams);
+  }, [searchParams, selectedEntryId, setSearchParams, visibleEntries]);
+
+  function setFilter<K extends keyof ExplorerFilters>(key: K, value: ExplorerFilters[K]) {
+    setIsMobileSheetOpen(false);
+    updateSearchParams(searchParams, { [key]: value || null, selected: null }, setSearchParams);
+  }
+
+  function setSearchFilter(value: string) {
+    setIsMobileSheetOpen(false);
+    setSearchInput(value);
+  }
+
+  function resetFilters() {
+    setIsMobileSheetOpen(false);
+    setSearchInput("");
+    updateSearchParams(searchParams, resetFilterPatch(), setSearchParams);
+  }
+
+  function selectCategoryEntry(id: string) {
+    setIsMobileSheetOpen(true);
+    updateSearchParams(searchParams, { selected: id }, setSearchParams);
+  }
+
+  async function handleLoadMore() {
+    if (!pageCursor || isLoadingMore) return;
+
+    setIsLoadingMore(true);
+    try {
+      const page = await loadExplorerPage({
+        profileId: profile.id,
+        category: activeTab,
+        filters,
+        cursor: pageCursor,
+        pageSize: PAGE_SIZE,
+      });
+
+      startTransition(() => {
+        setVisibleEntries((current) => [...current, ...page.entries]);
+        setPageCursor(page.nextCursor);
+        setHasMore(page.hasMore);
+      });
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }
+
+  return (
+    <CategoryExplorerContent
+      activeTab={activeTab}
+      facets={facets}
+      filters={filters}
+      entries={visibleEntries}
+      selectedEntry={selectedEntry}
+      isLoading={isPageLoading}
+      hasMore={hasMore}
+      isLoadingMore={isLoadingMore}
+      isMobileSheetOpen={isMobileSheetOpen}
+      searchValue={searchInput}
+      onFilterChange={setFilter}
+      onSearchChange={setSearchFilter}
+      onResetFilters={resetFilters}
+      onSelectEntry={selectCategoryEntry}
+      onCloseMobileSheet={() => setIsMobileSheetOpen(false)}
+      onLoadMore={() => void handleLoadMore()}
+    />
   );
 }

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -57,7 +57,10 @@ export function makeProfileSummary(overrides: Partial<SavedProfileSummary> = {})
 
 export function makeProfileMeta(overrides: Partial<ProfileMeta> = {}): ProfileMeta {
   const profile = makeSavedProfile();
+  return makeProfileMetaFromProfile(profile, overrides);
+}
 
+export function makeProfileMetaFromProfile(profile: SavedProfile, overrides: Partial<ProfileMeta> = {}): ProfileMeta {
   return {
     id: profile.id,
     name: profile.name,
@@ -73,6 +76,7 @@ export function makeProfileMeta(overrides: Partial<ProfileMeta> = {}): ProfileMe
       overview: profile.report.overview,
       tabs: profile.report.tabs,
       facets: profile.report.facets,
+      categoryFacets: profile.report.categoryFacets,
     },
     ...overrides,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,8 @@ export type ProviderName =
   | "Unknown";
 
 export type GenomeBuild = "GRCh37" | "GRCh38";
-export type InsightCategory = "medical" | "traits" | "drug";
+export const INSIGHT_CATEGORIES = ["medical", "traits", "drug"] as const;
+export type InsightCategory = (typeof INSIGHT_CATEGORIES)[number];
 export type ExplorerTab = "overview" | "medical" | "traits" | "drug" | "ai";
 export type InsightTone = "neutral" | "good" | "caution";
 export type FindingOutcome = "negative" | "positive" | "informational" | "missing";
@@ -264,15 +265,10 @@ export interface ReportData {
   tabs: TabSummary[];
   entries: ReportEntry[];
   facets: ReportFacets;
+  categoryFacets: Record<InsightCategory, ReportFacets>;
 }
 
-export interface ReportDataMeta {
-  reportVersion: number;
-  evidencePackVersion: string;
-  overview: ReportOverview;
-  tabs: TabSummary[];
-  facets: ReportFacets;
-}
+export type ReportDataMeta = Omit<ReportData, "entries">;
 
 export interface ProfileSupplements {
   evidence?: EvidenceSupplement;


### PR DESCRIPTION
## Summary

- Make explorer category tabs use independent mounted state so filters, selection, pagination, and scroll position reset when switching tabs.
- Persist per-category facet metadata and backfill older profile metadata without relying on MiniSearch.
- Render filter options from the active category only and sanitize stale cross-tab query filters.
- Simplify shared category/sort constants and memoize finding card selection handling.

## Why

Filters were shared across Medical, Traits, and Drug Response. That allowed unavailable data sources or filter options from one tab to affect another, and switching tabs could preserve list position/state in confusing ways. Category facets are now stored with report metadata so the explorer can load the right options without scanning every category on render.

## Validation

- `bun run test`
- `bun run build`

## Privacy impact

No new network or analytics surfaces. DNA/report data remains local; the change only affects local report metadata, IndexedDB-backed explorer state, and UI filtering behavior.