### PR TITLE
Switch to a streaming worker for processing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,12 @@ function countMatchedFindings(evidenceSupplement: EvidenceSupplement): number {
   return entryIds.size;
 }
 
+function createEvidenceWorker(): Worker {
+  return new Worker(new URL("./workers/evidenceEnrichment.worker.ts", import.meta.url), {
+    type: "module",
+  });
+}
+
 export default function App() {
   const parserWorkerRef = useRef<Worker | null>(null);
   const evidenceWorkerRef = useRef<Worker | null>(null);
@@ -98,9 +104,7 @@ export default function App() {
     parserWorkerRef.current = new Worker(new URL("./workers/dnaParser.worker.ts", import.meta.url), {
       type: "module",
     });
-    evidenceWorkerRef.current = new Worker(new URL("./workers/evidenceEnrichment.worker.ts", import.meta.url), {
-      type: "module",
-    });
+    evidenceWorkerRef.current = createEvidenceWorker();
 
     return () => {
       parserWorkerRef.current?.terminate();
@@ -113,19 +117,21 @@ export default function App() {
       throw new Error("Parser worker is not ready yet.");
     }
 
+    const worker = parserWorkerRef.current;
     const result = await new Promise<Exclude<ParserWorkerResponse, { type: "progress" }>>((resolve) => {
-      parserWorkerRef.current!.onmessage = (event: MessageEvent<ParserWorkerResponse>) => {
+      worker.onmessage = (event: MessageEvent<ParserWorkerResponse>) => {
         if ("type" in event.data && event.data.type === "progress") {
           onProgress?.(event.data.progress);
           return;
         }
 
         if ("ok" in event.data) {
+          worker.onmessage = null;
           resolve(event.data);
         }
       };
 
-      parserWorkerRef.current!.postMessage({ file });
+      worker.postMessage({ file });
     });
 
     if (!result.ok) {
@@ -143,8 +149,27 @@ export default function App() {
       throw new Error("Evidence worker is not ready yet.");
     }
 
+    const worker = evidenceWorkerRef.current;
     const result = await new Promise<EvidenceSupplement>((resolve, reject) => {
-      evidenceWorkerRef.current!.onmessage = (event: MessageEvent<EvidenceWorkerResponse>) => {
+      const clearWorkerHandlers = () => {
+        worker.onmessage = null;
+        worker.onerror = null;
+        worker.onmessageerror = null;
+      };
+      const resetWorkerAfterFailure = () => {
+        clearWorkerHandlers();
+
+        if (evidenceWorkerRef.current === worker) {
+          worker.terminate();
+          evidenceWorkerRef.current = createEvidenceWorker();
+        }
+      };
+      const handleWorkerTransportFailure = () => {
+        resetWorkerAfterFailure();
+        reject(new Error("Local evidence enrichment failed."));
+      };
+
+      worker.onmessage = (event: MessageEvent<EvidenceWorkerResponse>) => {
         const message = event.data;
         if (message.type === "progress") {
           onProgress?.(message.snapshot);
@@ -152,14 +177,21 @@ export default function App() {
         }
 
         if (message.type === "done") {
+          clearWorkerHandlers();
           resolve(message.supplement);
           return;
         }
 
+        clearWorkerHandlers();
         reject(new Error(message.error));
       };
+      worker.onerror = (event) => {
+        event.preventDefault();
+        handleWorkerTransportFailure();
+      };
+      worker.onmessageerror = handleWorkerTransportFailure;
 
-      evidenceWorkerRef.current!.postMessage({ type: "start", dna: parsed });
+      worker.postMessage({ type: "start", dna: parsed });
     });
 
     return result;

--- a/src/components/deana/marketing.tsx
+++ b/src/components/deana/marketing.tsx
@@ -348,8 +348,8 @@ export function MarketingProcessing({
   const heroVerb = isRefreshMode ? "Refreshing" : "Building";
   const bodyVerb = isRefreshMode ? "rematches" : "processes";
   const progressTitle = isRefreshMode ? "Refreshing evidence" : "Processing your data";
-  const isPreparingPack = snapshot.packStage && snapshot.packStage !== "matching";
-  const percent = isPreparingPack
+  const usesFixedProgressPercent = snapshot.packStage && snapshot.packStage !== "matching";
+  const percent = usesFixedProgressPercent
     ? 20
     : snapshot.totalRsids > 0
       ? Math.round((snapshot.processedRsids / snapshot.totalRsids) * 100)
@@ -362,12 +362,12 @@ export function MarketingProcessing({
   } else if (isSavingReport) {
     blockingReportMessage = "Saving your report…";
   }
-  const progressSummary = isPreparingPack
+  const progressSummary = usesFixedProgressPercent
     ? <span>Loading fixed evidence pack <strong>{snapshot.packVersion ?? "locally"}</strong></span>
     : (
       <span>Comparing <strong>{snapshot.processedRsids.toLocaleString()}</strong> of <strong>{snapshot.totalRsids.toLocaleString()}</strong> uploaded rsIDs locally</span>
     );
-  const currentLabel = isPreparingPack ? "Evidence pack" : "Current step";
+  const currentLabel = usesFixedProgressPercent ? "Evidence pack" : "Current step";
   const currentValue = snapshot.currentRsid ?? "Starting...";
 
   return (
@@ -414,9 +414,6 @@ export function MarketingProcessing({
         <Metric icon="upload" label="Uploaded rsIDs" value={snapshot.totalRsids} />
         <Metric icon="check" label="Processed" value={snapshot.processedRsids} />
         <Metric icon="spark" label="Matched findings" value={snapshot.matchedFindings} />
-        <Metric icon="x" label="Unmatched" value={snapshot.unmatchedRsids} />
-        <Metric icon="alert" label="Failed" value={snapshot.failedRsids} tone="coral" />
-        <Metric icon="refresh" label="Retries" value={snapshot.retries} />
       </section>
 
       {error ? (

--- a/src/lib/evidencePackData.test.ts
+++ b/src/lib/evidencePackData.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { LOCAL_EVIDENCE_PACK_VERSION, fetchLocalEvidencePack, matchEvidenceRecords } from "./evidencePackData";
-import type { EvidencePackManifest, EvidencePackRecord } from "../types";
+import {
+  LOCAL_EVIDENCE_PACK_VERSION,
+  fetchLocalEvidencePack,
+  matchEvidenceRecords,
+  matchLocalEvidencePack,
+} from "./evidencePackData";
+import type { CompactMarker, EvidencePackManifest, EvidencePackRecord } from "../types";
 
 async function sha256(value: string): Promise<string> {
   const bytes = new TextEncoder().encode(value);
@@ -85,6 +90,141 @@ describe("fetchLocalEvidencePack", () => {
     expect(pack.records).toEqual(neededRecords);
     expect(fetchedUrls.some((url) => url.endsWith("/shards/m000.json"))).toBe(false);
     expect(fetchedUrls.some((url) => url.endsWith("/shards/m001.json"))).toBe(true);
+  });
+
+  it("matches selected shards sequentially without materializing the pack", async () => {
+    const bucketZeroRecords = [makeRecord("bucket-zero", "rs2")];
+    const bucketOneRecords = [
+      makeRecord("bucket-one", "rs1"),
+      { ...makeRecord("missing-risk", "rs1"), riskAllele: "G" },
+    ];
+    const bucketZeroText = text(bucketZeroRecords);
+    const bucketOneText = text(bucketOneRecords);
+    const manifest: EvidencePackManifest = {
+      version: LOCAL_EVIDENCE_PACK_VERSION,
+      schemaVersion: 1,
+      generatedAt: "2026-04-25T00:00:00.000Z",
+      shardStrategy: "rsid-modulo",
+      shardModulo: 2,
+      shards: [
+        {
+          id: "m000",
+          recordsPath: "shards/m000.json",
+          recordsSha256: await sha256(bucketZeroText),
+          recordCount: bucketZeroRecords.length,
+          bucket: 0,
+        },
+        {
+          id: "m001",
+          recordsPath: "shards/m001.json",
+          recordsSha256: await sha256(bucketOneText),
+          recordCount: bucketOneRecords.length,
+          bucket: 1,
+        },
+      ],
+      recordCount: bucketZeroRecords.length + bucketOneRecords.length,
+      attribution: "test",
+      sources: [],
+    };
+    const fetchedShards: string[] = [];
+    let activeRecordFetches = 0;
+    let maxActiveRecordFetches = 0;
+    const fetchImpl = async (url: string | URL | Request): Promise<Response> => {
+      const href = String(url);
+      if (href.endsWith("/manifest.json")) {
+        return Response.json(manifest);
+      }
+
+      activeRecordFetches += 1;
+      maxActiveRecordFetches = Math.max(maxActiveRecordFetches, activeRecordFetches);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      activeRecordFetches -= 1;
+      fetchedShards.push(href);
+
+      if (href.endsWith("/shards/m000.json")) {
+        return new Response(bucketZeroText);
+      }
+      if (href.endsWith("/shards/m001.json")) {
+        return new Response(bucketOneText);
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const markers: CompactMarker[] = [
+      ["rs1", "1", 1, "AA"],
+      ["rs2", "1", 2, "AG"],
+    ];
+    const result = await matchLocalEvidencePack(fetchImpl as typeof fetch, markers, "GRCh37");
+
+    expect(result.matchedRecords).toEqual(matchEvidenceRecords(markers, [...bucketZeroRecords, ...bucketOneRecords], "GRCh37"));
+    expect(fetchedShards.map((url) => url.slice(url.lastIndexOf("/") + 1))).toEqual(["m000.json", "m001.json"]);
+    expect(maxActiveRecordFetches).toBe(1);
+  });
+
+  it("reports shard matching progress as each selected shard completes", async () => {
+    const firstRecords = [makeRecord("first", "rs1")];
+    const secondRecords = [makeRecord("second", "rs2")];
+    const firstText = text(firstRecords);
+    const secondText = text(secondRecords);
+    const manifest: EvidencePackManifest = {
+      version: LOCAL_EVIDENCE_PACK_VERSION,
+      schemaVersion: 1,
+      generatedAt: "2026-04-25T00:00:00.000Z",
+      shardStrategy: "rsid-modulo",
+      shardModulo: 2,
+      shards: [
+        {
+          id: "m000",
+          recordsPath: "shards/m000.json",
+          recordsSha256: await sha256(secondText),
+          recordCount: secondRecords.length,
+          bucket: 0,
+        },
+        {
+          id: "m001",
+          recordsPath: "shards/m001.json",
+          recordsSha256: await sha256(firstText),
+          recordCount: firstRecords.length,
+          bucket: 1,
+        },
+      ],
+      recordCount: firstRecords.length + secondRecords.length,
+      attribution: "test",
+      sources: [],
+    };
+    const fetchImpl = async (url: string | URL | Request): Promise<Response> => {
+      const href = String(url);
+      if (href.endsWith("/manifest.json")) return Response.json(manifest);
+      if (href.endsWith("/shards/m000.json")) return new Response(secondText);
+      if (href.endsWith("/shards/m001.json")) return new Response(firstText);
+      return new Response("not found", { status: 404 });
+    };
+    const progress: Array<{
+      processedShards: number;
+      processedRecords: number;
+      matchedEntryCount: number;
+      matchedRsidCount: number;
+      currentPath: string | null;
+    }> = [];
+
+    await matchLocalEvidencePack(fetchImpl as typeof fetch, [
+      ["rs1", "1", 1, "AA"],
+      ["rs2", "1", 2, "AG"],
+    ], undefined, (snapshot) => {
+      progress.push({
+        processedShards: snapshot.processedShards,
+        processedRecords: snapshot.processedRecords,
+        matchedEntryCount: snapshot.matchedEntryCount,
+        matchedRsidCount: snapshot.matchedRsidCount,
+        currentPath: snapshot.currentPath,
+      });
+    });
+
+    expect(progress).toEqual([
+      { processedShards: 0, processedRecords: 0, matchedEntryCount: 0, matchedRsidCount: 0, currentPath: null },
+      { processedShards: 1, processedRecords: 1, matchedEntryCount: 1, matchedRsidCount: 1, currentPath: "shards/m000.json" },
+      { processedShards: 2, processedRecords: 2, matchedEntryCount: 2, matchedRsidCount: 2, currentPath: "shards/m001.json" },
+    ]);
   });
 
   it("normalizes uploaded genotypes when matching local records", () => {

--- a/src/lib/evidencePackData.ts
+++ b/src/lib/evidencePackData.ts
@@ -12,6 +12,20 @@ export const LOCAL_EVIDENCE_PACK_BASE = `/evidence-packs/${LOCAL_EVIDENCE_PACK_V
 
 const DEFAULT_SHARD_MODULO = 256;
 
+type EvidencePackShard = NonNullable<EvidencePackManifest["shards"]>[number];
+type MarkerLookup = Map<string, CompactMarker>;
+
+export interface LocalEvidencePackMatchProgress {
+  manifest: EvidencePackManifest;
+  totalShards: number;
+  processedShards: number;
+  totalRecords: number;
+  processedRecords: number;
+  matchedEntryCount: number;
+  matchedRsidCount: number;
+  currentPath: string | null;
+}
+
 function canonicalGenotype(genotype: string | null): string | null {
   if (!genotype || genotype === "--") return null;
   if (/^[ACGT]{2}$/i.test(genotype)) {
@@ -114,6 +128,38 @@ function rsidBucket(rsid: string, modulo: number): number {
   return hash % modulo;
 }
 
+async function fetchLocalEvidencePackManifest(fetchImpl: typeof fetch): Promise<EvidencePackManifest> {
+  const manifestResponse = await fetchImpl(`${LOCAL_EVIDENCE_PACK_BASE}/manifest.json`, {
+    cache: "force-cache",
+  });
+  if (!manifestResponse.ok) {
+    throw new Error(`Local evidence pack manifest failed with ${manifestResponse.status}`);
+  }
+
+  const manifest = (await manifestResponse.json()) as EvidencePackManifest;
+  if (manifest.version !== LOCAL_EVIDENCE_PACK_VERSION || manifest.schemaVersion !== 1) {
+    throw new Error("Local evidence pack manifest is not compatible with this app version.");
+  }
+
+  return manifest;
+}
+
+function selectShardsForMarkers(
+  manifest: EvidencePackManifest,
+  markersForShardSelection: CompactMarker[],
+): EvidencePackShard[] {
+  if (!manifest.shards || manifest.shards.length === 0) return [];
+
+  if (markersForShardSelection.length === 0) return manifest.shards;
+
+  const modulo = manifest.shardModulo ?? DEFAULT_SHARD_MODULO;
+  const neededBuckets = new Set<number>();
+  for (const marker of markersForShardSelection) {
+    neededBuckets.add(rsidBucket(marker[0], modulo));
+  }
+  return manifest.shards.filter((shard) => neededBuckets.has(shard.bucket));
+}
+
 async function fetchRecordsFile(
   fetchImpl: typeof fetch,
   path: string,
@@ -144,27 +190,14 @@ export async function fetchLocalEvidencePack(
   manifest: EvidencePackManifest;
   records: EvidencePackRecord[];
 }> {
-  const manifestResponse = await fetchImpl(`${LOCAL_EVIDENCE_PACK_BASE}/manifest.json`, {
-    cache: "force-cache",
-  });
-  if (!manifestResponse.ok) {
-    throw new Error(`Local evidence pack manifest failed with ${manifestResponse.status}`);
-  }
-
-  const manifest = (await manifestResponse.json()) as EvidencePackManifest;
-  if (manifest.version !== LOCAL_EVIDENCE_PACK_VERSION || manifest.schemaVersion !== 1) {
-    throw new Error("Local evidence pack manifest is not compatible with this app version.");
-  }
+  const manifest = await fetchLocalEvidencePackManifest(fetchImpl);
 
   if (manifest.shards && manifest.shards.length > 0) {
-    const modulo = manifest.shardModulo ?? DEFAULT_SHARD_MODULO;
-    const neededBuckets = new Set(markersForShardSelection.map((marker) => rsidBucket(marker[0], modulo)));
-    const selectedShards = markersForShardSelection.length > 0
-      ? manifest.shards.filter((shard) => neededBuckets.has(shard.bucket))
-      : manifest.shards;
-    const records = (await Promise.all(
-      selectedShards.map((shard) => fetchRecordsFile(fetchImpl, shard.recordsPath, shard.recordsSha256)),
-    )).flat();
+    const selectedShards = selectShardsForMarkers(manifest, markersForShardSelection);
+    const records: EvidencePackRecord[] = [];
+    for (const shard of selectedShards) {
+      records.push(...await fetchRecordsFile(fetchImpl, shard.recordsPath, shard.recordsSha256));
+    }
 
     return { manifest, records };
   }
@@ -179,31 +212,150 @@ export async function fetchLocalEvidencePack(
   };
 }
 
+function createMarkerLookup(markers: CompactMarker[]): MarkerLookup {
+  const lookup: MarkerLookup = new Map();
+  for (const marker of markers) {
+    lookup.set(marker[0].toLowerCase(), marker);
+  }
+  return lookup;
+}
+
+function matchEvidenceRecord(
+  markerLookup: MarkerLookup,
+  record: EvidencePackRecord,
+  build?: string,
+): EvidencePackMatch | null {
+  const matchedMarkers: MatchedMarker[] = [];
+
+  for (let index = 0; index < record.markerIds.length; index += 1) {
+    const rsid = record.markerIds[index];
+    const marker = markerLookup.get(rsid.toLowerCase());
+    if (!markerMatchesRecord(marker, record, build)) continue;
+
+    const matchedMarker = markerToMatchedMarker(marker, rsid, record.genes[index] ?? record.genes[0], record, build);
+    if (matchedMarker.genotype) {
+      matchedMarkers.push(matchedMarker);
+    }
+  }
+
+  return matchedMarkers.length > 0 ? { record, matchedMarkers } : null;
+}
+
+function matchEvidenceRecordsWithMarkerLookup(
+  markerLookup: MarkerLookup,
+  records: EvidencePackRecord[],
+  build?: string,
+): EvidencePackMatch[] {
+  const matches: EvidencePackMatch[] = [];
+
+  for (const record of records) {
+    const match = matchEvidenceRecord(markerLookup, record, build);
+    if (match) matches.push(match);
+  }
+
+  return matches;
+}
+
+export async function matchLocalEvidencePack(
+  fetchImpl: typeof fetch = fetch,
+  markers: CompactMarker[] = [],
+  build?: string,
+  onProgress?: (progress: LocalEvidencePackMatchProgress) => void,
+): Promise<{
+  manifest: EvidencePackManifest;
+  matchedRecords: EvidencePackMatch[];
+  matchedEntryCount: number;
+  matchedRsidCount: number;
+}> {
+  const manifest = await fetchLocalEvidencePackManifest(fetchImpl);
+  const markerLookup = createMarkerLookup(markers);
+  const matchedRecords: EvidencePackMatch[] = [];
+  const matchedEntryIds = new Set<string>();
+  const matchedRsids = new Set<string>();
+
+  const addMatch = (match: EvidencePackMatch) => {
+    matchedRecords.push(match);
+    matchedEntryIds.add(match.record.entryId);
+    for (const marker of match.matchedMarkers) {
+      matchedRsids.add(marker.rsid.toLowerCase());
+    }
+  };
+
+  const addRecordMatches = (records: EvidencePackRecord[]) => {
+    for (const record of records) {
+      const match = matchEvidenceRecord(markerLookup, record, build);
+      if (match) addMatch(match);
+    }
+  };
+
+  const emitProgress = (
+    totalShards: number,
+    processedShards: number,
+    totalRecords: number,
+    processedRecords: number,
+    currentPath: string | null,
+  ) => {
+    onProgress?.({
+      manifest,
+      totalShards,
+      processedShards,
+      totalRecords,
+      processedRecords,
+      matchedEntryCount: matchedEntryIds.size,
+      matchedRsidCount: matchedRsids.size,
+      currentPath,
+    });
+  };
+
+  if (manifest.shards && manifest.shards.length > 0) {
+    const selectedShards = selectShardsForMarkers(manifest, markers);
+    const totalRecords = selectedShards.reduce((total, shard) => total + shard.recordCount, 0);
+    let processedRecords = 0;
+    let processedShards = 0;
+
+    emitProgress(selectedShards.length, processedShards, totalRecords, processedRecords, null);
+
+    for (const shard of selectedShards) {
+      const records = await fetchRecordsFile(fetchImpl, shard.recordsPath, shard.recordsSha256);
+      addRecordMatches(records);
+      processedRecords += shard.recordCount;
+      processedShards += 1;
+
+      emitProgress(selectedShards.length, processedShards, totalRecords, processedRecords, shard.recordsPath);
+    }
+
+    return {
+      manifest,
+      matchedRecords,
+      matchedEntryCount: matchedEntryIds.size,
+      matchedRsidCount: matchedRsids.size,
+    };
+  }
+
+  if (!manifest.recordsPath || !manifest.recordsSha256) {
+    throw new Error("Local evidence pack manifest did not include records or shards.");
+  }
+
+  emitProgress(1, 0, manifest.recordCount ?? 0, 0, null);
+
+  const records = await fetchRecordsFile(fetchImpl, manifest.recordsPath, manifest.recordsSha256);
+  addRecordMatches(records);
+
+  const totalRecords = manifest.recordCount ?? records.length;
+  emitProgress(1, 1, totalRecords, totalRecords, manifest.recordsPath);
+
+  return {
+    manifest,
+    matchedRecords,
+    matchedEntryCount: matchedEntryIds.size,
+    matchedRsidCount: matchedRsids.size,
+  };
+}
+
 export function matchEvidenceRecords(
   markers: CompactMarker[],
   records: EvidencePackRecord[],
   build?: string,
 ): EvidencePackMatch[] {
-  const markerMap = new Map(markers.map((marker) => [marker[0].toLowerCase(), marker]));
-  const matches: EvidencePackMatch[] = [];
-
-  for (const record of records) {
-    const matchedMarkers: MatchedMarker[] = [];
-
-    record.markerIds.forEach((rsid, index) => {
-      const marker = markerMap.get(rsid.toLowerCase());
-      if (!markerMatchesRecord(marker, record, build)) return;
-
-      const matchedMarker = markerToMatchedMarker(marker, rsid, record.genes[index] ?? record.genes[0], record, build);
-      if (matchedMarker.genotype) {
-        matchedMarkers.push(matchedMarker);
-      }
-    });
-
-    if (matchedMarkers.length > 0) {
-      matches.push({ record, matchedMarkers });
-    }
-  }
-
-  return matches;
+  return matchEvidenceRecordsWithMarkerLookup(createMarkerLookup(markers), records, build);
 }

--- a/src/workers/evidenceEnrichment.worker.ts
+++ b/src/workers/evidenceEnrichment.worker.ts
@@ -1,4 +1,4 @@
-import { fetchLocalEvidencePack, matchEvidenceRecords } from "../lib/evidencePackData";
+import { matchLocalEvidencePack, type LocalEvidencePackMatchProgress } from "../lib/evidencePackData";
 import {
   EvidenceProgressSnapshot,
   EvidenceSupplement,
@@ -28,6 +28,25 @@ type ErrorResponse = {
 };
 
 type WorkerResponse = ProgressResponse | DoneResponse | ErrorResponse;
+
+const MATCHING_PROGRESS_FLOOR = 0.05;
+const MATCHING_PROGRESS_WEIGHT = 0.9;
+const FINALIZING_PROGRESS_RATIO = 0.95;
+
+function recordProgressRatio(progress: LocalEvidencePackMatchProgress): number {
+  if (progress.totalRecords > 0) {
+    return progress.processedRecords / progress.totalRecords;
+  }
+  if (progress.totalShards === 0) {
+    return 1;
+  }
+  return progress.processedShards / progress.totalShards;
+}
+
+function estimateProcessedRsids(markerCount: number, progress: LocalEvidencePackMatchProgress): number {
+  const weightedProgress = Math.max(MATCHING_PROGRESS_FLOOR, recordProgressRatio(progress) * MATCHING_PROGRESS_WEIGHT);
+  return Math.min(markerCount, Math.round(markerCount * weightedProgress));
+}
 
 function postProgress(
   post: (message: WorkerResponse) => void,
@@ -59,31 +78,33 @@ async function buildEvidenceSupplement(
     currentRsid: "Loading local evidence-pack manifest",
   });
 
-  const { manifest, records } = await fetchLocalEvidencePack(fetch, dna.markers);
+  const { manifest, matchedRecords, matchedEntryCount, matchedRsidCount } = await matchLocalEvidencePack(fetch, dna.markers, dna.build, (progress) => {
+    postProgress(post, dna, {
+      packStage: progress.processedShards === 0 ? "records" : "matching",
+      packVersion: progress.manifest.version,
+      processedRsids: estimateProcessedRsids(dna.markerCount, progress),
+      matchedFindings: progress.matchedEntryCount,
+      unmatchedRsids: Math.max(0, dna.markerCount - progress.matchedRsidCount),
+      currentRsid: progress.currentPath
+        ? `Matched evidence shard ${progress.processedShards} of ${progress.totalShards}`
+        : "Loading local evidence shards",
+    });
+  });
 
   postProgress(post, dna, {
     packStage: "matching",
     packVersion: manifest.version,
-    processedRsids: Math.round(dna.markerCount * 0.35),
-    currentRsid: "Matching bundled evidence sources locally",
+    processedRsids: Math.round(dna.markerCount * FINALIZING_PROGRESS_RATIO),
+    currentRsid: "Finalizing bundled evidence matches",
   });
 
-  const matchedRecords = matchEvidenceRecords(dna.markers, records, dna.build);
-  const matchedRsids = new Set<string>();
-  const matchedEntryIds = new Set<string>();
-  for (const match of matchedRecords) {
-    matchedEntryIds.add(match.record.entryId);
-    for (const marker of match.matchedMarkers) {
-      matchedRsids.add(marker.rsid.toLowerCase());
-    }
-  }
-  const unmatchedRsids = Math.max(0, dna.markerCount - matchedRsids.size);
+  const unmatchedRsids = Math.max(0, dna.markerCount - matchedRsidCount);
 
   postProgress(post, dna, {
     packStage: "matching",
     packVersion: manifest.version,
     processedRsids: dna.markerCount,
-    matchedFindings: matchedEntryIds.size,
+    matchedFindings: matchedEntryCount,
     unmatchedRsids,
     currentRsid: "Matched bundled evidence records",
   });


### PR DESCRIPTION
This PR switches to a streaming worker for evidence enrichment to mitigate crashes in memory restricted browsers such as Safari on iOS.