### PR TITLE
Update GitHub URLs to DeanaDNA/deana

### DIFF
--- a/src/components/deana/marketing.tsx
+++ b/src/components/deana/marketing.tsx
@@ -2,7 +2,7 @@ import type { DragEvent } from "react";
 import type { DnaParseProgress, EvidenceProgressSnapshot, ParsedDnaFile } from "../../types";
 import { DeanaWordmark, Icon } from "./ui";
 
-export const DEANA_GITHUB_URL = "https://github.com/steve228uk/deana";
+export const DEANA_GITHUB_URL = "https://github.com/DeanaDNA/deana";
 export const DEANA_LICENSE_URL = `${DEANA_GITHUB_URL}/blob/HEAD/LICENSE.md`;
 export const DEANA_SUBREDDIT_URL = "https://www.reddit.com/r/deanadna";
 export const DEANA_SUPPORT_URL = "https://ko-fi.com/steve228uk";

--- a/src/lib/clingen/fetch.ts
+++ b/src/lib/clingen/fetch.ts
@@ -1,5 +1,5 @@
 const USER_AGENT =
-  "Mozilla/5.0 (compatible; deana-evidence-sync/1.0; +https://github.com/steve228uk/deana)";
+  "Mozilla/5.0 (compatible; deana-evidence-sync/1.0; +https://github.com/DeanaDNA/deana)";
 
 async function fetchClinGen(url: string, accept: string): Promise<Response> {
   const res = await fetch(url, {


### PR DESCRIPTION
## Summary
- update the marketing GitHub URL to the new repository owner
- update the ClinGen fetch user-agent repository URL

## Testing
- not run (URL-only change)